### PR TITLE
Allows ignoring of unknown properties in yml configurations.

### DIFF
--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/properties/CasProperties.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/properties/CasProperties.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 @Setter
 @Configuration
-@ConfigurationProperties(prefix = "cas", ignoreUnknownFields = false)
+@ConfigurationProperties(prefix = "cas")
 public class CasProperties {
     @Getter
     @Setter

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/properties/CommonProperties.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/properties/CommonProperties.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 @Setter
 @Configuration
-@ConfigurationProperties(prefix = "common", ignoreUnknownFields = false)
+@ConfigurationProperties(prefix = "common")
 public class CommonProperties {
     private String rootOrganizationOid;
     private String groupOrganizationId;

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/properties/DatasourceProperties.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/properties/DatasourceProperties.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 @Setter
 @Configuration
-@ConfigurationProperties(prefix = "datasource", ignoreUnknownFields = false)
+@ConfigurationProperties(prefix = "datasource")
 public class DatasourceProperties {
     private String url;
     private String testUrl;

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/properties/EmailInvitation.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/properties/EmailInvitation.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 @Setter
 @Configuration
-@ConfigurationProperties(prefix = "tasks.emailInvitation", ignoreUnknownFields = false)
+@ConfigurationProperties(prefix = "tasks.emailInvitation")
 public class EmailInvitation {
     private String senderEmail;
 }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/properties/HikariProperties.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/properties/HikariProperties.java
@@ -5,6 +5,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConfigurationProperties(prefix = "hikari.datasource", ignoreUnknownFields = false)
+@ConfigurationProperties(prefix = "hikari.datasource")
 public class HikariProperties extends HikariConfig {
 }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/properties/ServiceUsersProperties.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/properties/ServiceUsersProperties.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 @Setter
 @Configuration
-@ConfigurationProperties(prefix = "service-users", ignoreUnknownFields = false)
+@ConfigurationProperties(prefix = "service-users")
 public class ServiceUsersProperties {
     private ServiceUserAccount viestinta;
     private ServiceUserAccount oppijanumerorekisteri;


### PR DESCRIPTION
Previously preparing to new features in e.g. api tests caused problems when run against different branches. Would cause the same problem locally in development: a developer wouldn't be able to have configuration supporting different branches.