### PR TITLE
KJHH-955_organisaatioviite

### DIFF
--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/mapper/LocalDateConverter.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/mapper/LocalDateConverter.java
@@ -2,7 +2,6 @@ package fi.vm.sade.kayttooikeus.config.mapper;
 
 import ma.glasnost.orika.MappingContext;
 import ma.glasnost.orika.converter.BidirectionalConverter;
-import ma.glasnost.orika.converter.builtin.PassThroughConverter;
 import ma.glasnost.orika.metadata.Type;
 import org.springframework.stereotype.Component;
 

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttooikeusAnomusServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttooikeusAnomusServiceImpl.java
@@ -161,8 +161,10 @@ public class KayttooikeusAnomusServiceImpl extends AbstractService implements Ka
                 .orElseThrow(() -> new NotFoundException("Could not find kayttooikeusryhma with id " + kayttooikeusryhmaId.toString()))
                 .getOrganisaatioViite();
         List<String> currentUserOrganisaatioOids = this.organisaatioHenkiloDataRepository
-                .findByHenkiloOidHenkilo(UserDetailsUtil.getCurrentUserOid())
-                .stream().map(OrganisaatioHenkilo::getOrganisaatioOid).collect(Collectors.toList());
+                .findByHenkiloOidHenkilo(UserDetailsUtil.getCurrentUserOid()).stream()
+                .filter(((Predicate<OrganisaatioHenkilo>) OrganisaatioHenkilo::isPassivoitu).negate())
+                .map(OrganisaatioHenkilo::getOrganisaatioOid)
+                .collect(Collectors.toList());
 
         // Organisaatiohenkilo limitations are valid
         if(!CollectionUtils.isEmpty(organisaatioViite)

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttooikeusAnomusServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttooikeusAnomusServiceImpl.java
@@ -27,6 +27,9 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 
 import static java.util.stream.Collectors.toSet;
+
+import fi.vm.sade.kayttooikeus.util.UserDetailsUtil;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,8 +39,12 @@ import org.springframework.validation.BindException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class KayttooikeusAnomusServiceImpl extends AbstractService implements KayttooikeusAnomusService {
 
     private final HaettuKayttooikeusRyhmaDataRepository haettuKayttooikeusRyhmaDataRepository;
@@ -48,6 +55,7 @@ public class KayttooikeusAnomusServiceImpl extends AbstractService implements Ka
     private final KayttoOikeusRyhmaTapahtumaHistoriaDataRepository kayttoOikeusRyhmaTapahtumaHistoriaDataRepository;
     private final KayttooikeusryhmaDataRepository kayttooikeusryhmaDataRepository;
     private final AnomusRepository anomusRepository;
+    private final OrganisaatioHenkiloDataRepository organisaatioHenkiloDataRepository;
 
     private final OrikaBeanMapper mapper;
     private final LocalizationService localizationService;
@@ -59,39 +67,6 @@ public class KayttooikeusAnomusServiceImpl extends AbstractService implements Ka
     private final CommonProperties commonProperties;
 
     private final OrganisaatioClient organisaatioClient;
-
-    @Autowired
-    public KayttooikeusAnomusServiceImpl(HaettuKayttooikeusRyhmaDataRepository haettuKayttooikeusRyhmaDataRepository,
-                                         HenkiloDataRepository henkiloDataRepository,
-                                         HenkiloHibernateRepository henkiloHibernateRepository,
-                                         MyonnettyKayttoOikeusRyhmaTapahtumaDataRepository myonnettyKayttoOikeusRyhmaTapahtumaDataRepository,
-                                         KayttoOikeusRyhmaMyontoViiteRepository kayttoOikeusRyhmaMyontoViiteRepository,
-                                         KayttoOikeusRyhmaTapahtumaHistoriaDataRepository kayttoOikeusRyhmaTapahtumaHistoriaDataRepository,
-                                         OrikaBeanMapper orikaBeanMapper,
-                                         LocalizationService localizationService,
-                                         EmailService emailService,
-                                         HaettuKayttooikeusryhmaValidator haettuKayttooikeusryhmaValidator,
-                                         PermissionCheckerService permissionCheckerService,
-                                         KayttooikeusryhmaDataRepository kayttooikeusryhmaDataRepository,
-                                         CommonProperties commonProperties,
-                                         OrganisaatioClient organisaatioClient,
-                                         AnomusRepository anomusRepository) {
-        this.haettuKayttooikeusRyhmaDataRepository = haettuKayttooikeusRyhmaDataRepository;
-        this.henkiloDataRepository = henkiloDataRepository;
-        this.henkiloHibernateRepository = henkiloHibernateRepository;
-        this.myonnettyKayttoOikeusRyhmaTapahtumaDataRepository = myonnettyKayttoOikeusRyhmaTapahtumaDataRepository;
-        this.kayttoOikeusRyhmaMyontoViiteRepository = kayttoOikeusRyhmaMyontoViiteRepository;
-        this.kayttoOikeusRyhmaTapahtumaHistoriaDataRepository = kayttoOikeusRyhmaTapahtumaHistoriaDataRepository;
-        this.mapper = orikaBeanMapper;
-        this.localizationService = localizationService;
-        this.emailService = emailService;
-        this.haettuKayttooikeusryhmaValidator = haettuKayttooikeusryhmaValidator;
-        this.permissionCheckerService = permissionCheckerService;
-        this.kayttooikeusryhmaDataRepository = kayttooikeusryhmaDataRepository;
-        this.commonProperties = commonProperties;
-        this.organisaatioClient = organisaatioClient;
-        this.anomusRepository = anomusRepository;
-    }
 
     @Transactional(readOnly = true)
     @Override
@@ -125,8 +100,7 @@ public class KayttooikeusAnomusServiceImpl extends AbstractService implements Ka
         // Permission checks for declining requisition (there are separate checks for granting)
         this.notEditingOwnData(anojanAnomus.getHenkilo().getOidHenkilo());
         this.inSameOrParentOrganisation(anojanAnomus.getOrganisaatioOid());
-        this.organisaatioViiteLimitationsAreValid(anottuKayttoOikeusRyhma.getId(),
-                anojanAnomus.getOrganisaatioOid());
+        this.organisaatioViiteLimitationsAreValid(anottuKayttoOikeusRyhma.getId());
         this.kayttooikeusryhmaLimitationsAreValid(anottuKayttoOikeusRyhma.getId());
 
         // Post validation
@@ -182,15 +156,19 @@ public class KayttooikeusAnomusServiceImpl extends AbstractService implements Ka
         }
     }
 
-    private void organisaatioViiteLimitationsAreValid(Long kayttooikeusryhmaId, String organisaatioOid) {
+    private void organisaatioViiteLimitationsAreValid(Long kayttooikeusryhmaId) {
         Set<OrganisaatioViite> organisaatioViite = this.kayttooikeusryhmaDataRepository.findById(kayttooikeusryhmaId)
                 .orElseThrow(() -> new NotFoundException("Could not find kayttooikeusryhma with id " + kayttooikeusryhmaId.toString()))
                 .getOrganisaatioViite();
+        List<String> currentUserOrganisaatioOids = this.organisaatioHenkiloDataRepository
+                .findByHenkiloOidHenkilo(UserDetailsUtil.getCurrentUserOid())
+                .stream().map(OrganisaatioHenkilo::getOrganisaatioOid).collect(Collectors.toList());
+
         // Organisaatiohenkilo limitations are valid
         if(!CollectionUtils.isEmpty(organisaatioViite)
                 // only root organisation should not have organisaatioviite
-                && !commonProperties.getRootOrganizationOid().equals(organisaatioOid)
-                && !this.permissionCheckerService.organisaatioLimitationCheck(organisaatioOid, organisaatioViite)) {
+                && currentUserOrganisaatioOids.stream().noneMatch((orgOid) -> commonProperties.getRootOrganizationOid().equals(orgOid))
+                && currentUserOrganisaatioOids.stream().noneMatch((orgOid) -> this.permissionCheckerService.organisaatioLimitationCheck(orgOid, organisaatioViite))) {
             throw new ForbiddenException("Target organization has invalid organization type");
         }
     }
@@ -243,7 +221,7 @@ public class KayttooikeusAnomusServiceImpl extends AbstractService implements Ka
         this.notEditingOwnData(anojaOid);
         this.inSameOrParentOrganisation(organisaatioOid);
         updateHaettuKayttooikeusryhmaDtoList.forEach(updateHaettuKayttooikeusryhmaDto -> {
-                    this.organisaatioViiteLimitationsAreValid(updateHaettuKayttooikeusryhmaDto.getId(), organisaatioOid);
+                    this.organisaatioViiteLimitationsAreValid(updateHaettuKayttooikeusryhmaDto.getId());
                     this.kayttooikeusryhmaLimitationsAreValid(updateHaettuKayttooikeusryhmaDto.getId());
         });
 

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/KayttooikeusAnomusServiceTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/KayttooikeusAnomusServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.LocalDate;
@@ -88,6 +89,9 @@ public class KayttooikeusAnomusServiceTest {
     @MockBean
     private EmailService emailService;
 
+    @MockBean
+    private OrganisaatioHenkiloDataRepository organisaatioHenkiloDataRepository;
+
     @Captor
     private ArgumentCaptor<Set<String>> henkiloOidsCaptor;
 
@@ -105,15 +109,16 @@ public class KayttooikeusAnomusServiceTest {
                 this.myonnettyKayttoOikeusRyhmaTapahtumaDataRepository,
                 this.kayttoOikeusRyhmaMyontoViiteRepository,
                 this.kayttoOikeusRyhmaTapahtumaHistoriaDataRepository,
+                this.kayttooikeusryhmaDataRepository,
+                this.anomusRepository,
+                this.organisaatioHenkiloDataRepository,
                 this.orikaBeanMapper,
                 this.localizationService,
                 this.emailService,
                 this.haettuKayttooikeusryhmaValidator,
                 this.permissionCheckerService,
-                this.kayttooikeusryhmaDataRepository,
                 commonProperties,
-                this.organisaatioClient,
-                this.anomusRepository)
+                this.organisaatioClient)
         );
     }
 
@@ -156,6 +161,7 @@ public class KayttooikeusAnomusServiceTest {
     }
 
     @Test
+    @WithMockUser("1.2.3.4.1")
     public void grantKayttooikeusryhmaForDisabledOrganisaatioHenkilo() {
         given(this.permissionCheckerService.notOwnData(anyString())).willReturn(true);
         given(this.permissionCheckerService.checkRoleForOrganisation(any(), any())).willReturn(true);
@@ -164,7 +170,9 @@ public class KayttooikeusAnomusServiceTest {
         given(this.henkiloDataRepository.findByOidHenkilo("1.2.3.4.1"))
                 .willReturn(Optional.of(createHenkiloWithOrganisaatio("1.2.3.4.5", "1.2.0.0.1", true)));
         given(this.permissionCheckerService.getCurrentUserOid()).willReturn("1.2.3.4.1");
-        given(this.permissionCheckerService.organisaatioLimitationCheck(anyString(), anySetOf(OrganisaatioViite.class))).willReturn(true);
+        given(this.permissionCheckerService.organisaatioLimitationCheck(eq("1.2.0.0.1"), anySetOf(OrganisaatioViite.class))).willReturn(true);
+        given(this.organisaatioHenkiloDataRepository.findByHenkiloOidHenkilo("1.2.3.4.1"))
+                .willReturn(Lists.newArrayList(OrganisaatioHenkilo.builder().organisaatioOid("1.2.0.0.1").build()));
         given(this.permissionCheckerService.kayttooikeusMyontoviiteLimitationCheck(2001L)).willReturn(true);
         given(this.myonnettyKayttoOikeusRyhmaTapahtumaDataRepository.findMyonnettyTapahtuma(2001L,
                 "1.2.0.0.1", "1.2.3.4.5"))
@@ -210,6 +218,7 @@ public class KayttooikeusAnomusServiceTest {
 
     // MyonnettyKayttooikeusryhmaTapahtuma already exists
     @Test
+    @WithMockUser("1.2.3.4.1")
     public void grantKayttooikeusryhmaUusittu() {
         given(this.permissionCheckerService.notOwnData(anyString())).willReturn(true);
         given(this.permissionCheckerService.checkRoleForOrganisation(any(), any())).willReturn(true);
@@ -217,7 +226,9 @@ public class KayttooikeusAnomusServiceTest {
         given(this.henkiloDataRepository.findByOidHenkilo("1.2.3.4.5")).willReturn(Optional.of(createHenkilo("1.2.3.4.5")));
         given(this.henkiloDataRepository.findByOidHenkilo("1.2.3.4.1")).willReturn(Optional.of(createHenkilo("1.2.3.4.5")));
         given(this.permissionCheckerService.getCurrentUserOid()).willReturn("1.2.3.4.1");
-        given(this.permissionCheckerService.organisaatioLimitationCheck(anyString(), anySetOf(OrganisaatioViite.class))).willReturn(true);
+        given(this.permissionCheckerService.organisaatioLimitationCheck(eq("1.2.0.0.1"), anySetOf(OrganisaatioViite.class))).willReturn(true);
+        given(this.organisaatioHenkiloDataRepository.findByHenkiloOidHenkilo("1.2.3.4.1"))
+                .willReturn(Lists.newArrayList(OrganisaatioHenkilo.builder().organisaatioOid("1.2.0.0.1").build()));
         given(this.permissionCheckerService.kayttooikeusMyontoviiteLimitationCheck(2001L)).willReturn(true);
         given(this.myonnettyKayttoOikeusRyhmaTapahtumaDataRepository.findMyonnettyTapahtuma(2001L,
                 "1.2.0.0.1", "1.2.3.4.5"))
@@ -248,6 +259,7 @@ public class KayttooikeusAnomusServiceTest {
 
 
     @Test
+    @WithMockUser("1.2.3.4.1")
     public void updateHaettuKayttooikeusryhmaMyonnetty() {
         HaettuKayttoOikeusRyhma haettuKayttoOikeusRyhma = createHaettuKayttoOikeusRyhma("1.2.3.4.5", "1.2.3.4.1",
                 "1.2.0.0.1", "devaaja", "Haluan devata", 2001L);
@@ -259,7 +271,9 @@ public class KayttooikeusAnomusServiceTest {
         given(this.permissionCheckerService.checkRoleForOrganisation(anyListOf(String.class), anyListOf(String.class)))
                 .willReturn(true);
         given(this.permissionCheckerService.getCurrentUserOid()).willReturn("1.2.3.4.1");
-        given(this.permissionCheckerService.organisaatioLimitationCheck(anyString(), anySetOf(OrganisaatioViite.class))).willReturn(true);
+        given(this.permissionCheckerService.organisaatioLimitationCheck(eq("1.2.0.0.1"), anySetOf(OrganisaatioViite.class))).willReturn(true);
+        given(this.organisaatioHenkiloDataRepository.findByHenkiloOidHenkilo("1.2.3.4.1"))
+                .willReturn(Lists.newArrayList(OrganisaatioHenkilo.builder().organisaatioOid("1.2.0.0.1").build()));
         given(this.permissionCheckerService.kayttooikeusMyontoviiteLimitationCheck(2001L)).willReturn(true);
         given(this.permissionCheckerService.notOwnData("1.2.3.4.5")).willReturn(true);
         given(this.henkiloDataRepository.findByOidHenkilo("1.2.3.4.5")).willReturn(Optional.of(createHenkilo("1.2.3.4.5")));
@@ -280,6 +294,7 @@ public class KayttooikeusAnomusServiceTest {
     }
 
     @Test
+    @WithMockUser("1.2.3.4.1")
     public void updateHaettuKayttooikeusryhmaHylatty() {
         HaettuKayttoOikeusRyhma haettuKayttoOikeusRyhma = createHaettuKayttoOikeusRyhma("1.2.3.4.5", "1.2.3.4.1",
                 "1.2.0.0.1", "devaaja", "Haluan devata", 2001L);
@@ -291,7 +306,9 @@ public class KayttooikeusAnomusServiceTest {
         given(this.permissionCheckerService.checkRoleForOrganisation(anyListOf(String.class), anyListOf(String.class)))
                 .willReturn(true);
         given(this.permissionCheckerService.getCurrentUserOid()).willReturn("1.2.3.4.1");
-        given(this.permissionCheckerService.organisaatioLimitationCheck(anyString(), anySetOf(OrganisaatioViite.class))).willReturn(true);
+        given(this.permissionCheckerService.organisaatioLimitationCheck(eq("1.2.0.0.1"), anySetOf(OrganisaatioViite.class))).willReturn(true);
+        given(this.organisaatioHenkiloDataRepository.findByHenkiloOidHenkilo("1.2.3.4.1"))
+                .willReturn(Lists.newArrayList(OrganisaatioHenkilo.builder().organisaatioOid("1.2.0.0.1").build()));
         given(this.permissionCheckerService.kayttooikeusMyontoviiteLimitationCheck(2001L)).willReturn(true);
         given(this.permissionCheckerService.notOwnData("1.2.3.4.5")).willReturn(true);
         given(this.henkiloDataRepository.findByOidHenkilo("1.2.3.4.5")).willReturn(Optional.of(createHenkilo("1.2.3.4.5")));
@@ -306,6 +323,7 @@ public class KayttooikeusAnomusServiceTest {
     }
 
     @Test
+    @WithMockUser("1.2.3.4.1")
     public void updateHaettuKayttooikeusryhmaHylkaaOneFromAnomus() {
         HaettuKayttoOikeusRyhma haettuKayttoOikeusRyhma = createHaettuKayttoOikeusRyhma("1.2.3.4.5", "1.2.3.4.1",
                 "1.2.0.0.1", "devaaja", "Haluan devata", 2001L);
@@ -321,7 +339,9 @@ public class KayttooikeusAnomusServiceTest {
         given(this.permissionCheckerService.checkRoleForOrganisation(anyListOf(String.class), anyListOf(String.class)))
                 .willReturn(true);
         given(this.permissionCheckerService.getCurrentUserOid()).willReturn("1.2.3.4.1");
-        given(this.permissionCheckerService.organisaatioLimitationCheck(anyString(), anySetOf(OrganisaatioViite.class))).willReturn(true);
+        given(this.permissionCheckerService.organisaatioLimitationCheck(eq("1.2.0.0.1"), anySetOf(OrganisaatioViite.class))).willReturn(true);
+        given(this.organisaatioHenkiloDataRepository.findByHenkiloOidHenkilo("1.2.3.4.1"))
+                .willReturn(Lists.newArrayList(OrganisaatioHenkilo.builder().organisaatioOid("1.2.0.0.1").build()));
         given(this.permissionCheckerService.kayttooikeusMyontoviiteLimitationCheck(2001L)).willReturn(true);
         given(this.permissionCheckerService.notOwnData("1.2.3.4.5")).willReturn(true);
         given(this.henkiloDataRepository.findByOidHenkilo("1.2.3.4.5")).willReturn(Optional.of(createHenkilo("1.2.3.4.5")));

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/PermissionCheckerTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/PermissionCheckerTest.java
@@ -247,7 +247,7 @@ public class PermissionCheckerTest {
 
     @Test
     public void organisaatioLimitationCheckOrganisaatioNoChildrenWrongOid() {
-        given(this.organisaatioClient.getOrganisaatioPerustiedotCached(anyString(), any()))
+        given(this.organisaatioClient.getOrganisaatioPerustiedotCached(eq("1.2.3.4.5"), any()))
                 .willReturn(CreateUtil.createOrganisaatioPerustietoNoChildren("1.2.3.4.5"));
         OrganisaatioViite organisaatioViite = OrganisaatioViite.builder().organisaatioTyyppi("1.2.3.4.1").build();
         boolean hasPermission = this.permissionChecker
@@ -257,7 +257,7 @@ public class PermissionCheckerTest {
 
     @Test
     public void organisaatioLimitationCheckOrganisaatioNoChildrenCorrectOid() {
-        given(this.organisaatioClient.getOrganisaatioPerustiedotCached(anyString(), any()))
+        given(this.organisaatioClient.getOrganisaatioPerustiedotCached(eq("1.2.3.4.5"), any()))
                 .willReturn(CreateUtil.createOrganisaatioPerustietoNoChildren("1.2.3.4.5"));
         OrganisaatioViite organisaatioViite = OrganisaatioViite.builder().organisaatioTyyppi("1.2.3.4.5").build();
         boolean hasPermission = this.permissionChecker
@@ -267,18 +267,18 @@ public class PermissionCheckerTest {
 
     @Test
     public void organisaatioLimitationCheckOrganisaatioWithChildrenViiteMatchesChildTyyppi() {
-        given(this.organisaatioClient.getOrganisaatioPerustiedotCached(anyString(), any()))
+        given(this.organisaatioClient.getOrganisaatioPerustiedotCached(eq("1.2.3.4.5"), any()))
                 .willReturn(CreateUtil.createOrganisaatioPerustietoWithChild("1.2.3.4.5", "1.2.3.4.6",
                         "oppilaitostyyppi_11#1"));
         OrganisaatioViite organisaatioViite = OrganisaatioViite.builder().organisaatioTyyppi("11").build();
         boolean hasPermission = this.permissionChecker
-                .organisaatioLimitationCheck("1.2.3.4.6", Sets.newHashSet(organisaatioViite));
+                .organisaatioLimitationCheck("1.2.3.4.5", Sets.newHashSet(organisaatioViite));
         assertThat(hasPermission).isTrue();
     }
 
     @Test
     public void organisaatioLimitationCheckOrganisaatioWithChildrenViiteMatchesParentOid() {
-        given(this.organisaatioClient.getOrganisaatioPerustiedotCached(anyString(), any()))
+        given(this.organisaatioClient.getOrganisaatioPerustiedotCached(eq("1.2.3.4.5"), any()))
                 .willReturn(CreateUtil.createOrganisaatioPerustietoWithChild("1.2.3.4.5", "1.2.3.4.6",
                         "oppilaitostyyppi_11#1"));
         OrganisaatioViite organisaatioViite = OrganisaatioViite.builder().organisaatioTyyppi("1.2.3.4.5").build();
@@ -289,7 +289,7 @@ public class PermissionCheckerTest {
 
     @Test
     public void organisaatioLimitationCheckOrganisaatioWithChildrenViiteNoMatch() {
-        given(this.organisaatioClient.getOrganisaatioPerustiedotCached(anyString(), any()))
+        given(this.organisaatioClient.getOrganisaatioPerustiedotCached(eq("1.2.3.4.5"), any()))
                 .willReturn(CreateUtil.createOrganisaatioPerustietoWithChild("1.2.3.4.5", "1.2.3.4.6",
                         "oppilaitostyyppi_11#1"));
         OrganisaatioViite organisaatioViite = OrganisaatioViite.builder().organisaatioTyyppi("1.2.3.4.1").build();


### PR DESCRIPTION
- Fix organisaatioviite to be checked from calling user organisations, not from the organisation to be granted.