### PR TITLE
Kjhh 1117 henkilohaku optimointi

### DIFF
--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/controller/HenkiloController.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/controller/HenkiloController.java
@@ -1,26 +1,27 @@
 package fi.vm.sade.kayttooikeus.controller;
 
 import fi.vm.sade.kayttooikeus.dto.*;
-import fi.vm.sade.kayttooikeus.enumeration.OrderByHenkilohaku;
-import fi.vm.sade.kayttooikeus.repositories.criteria.KayttooikeusCriteria;
-import fi.vm.sade.kayttooikeus.repositories.criteria.OrganisaatioHenkiloCriteria;
 import fi.vm.sade.kayttooikeus.dto.permissioncheck.ExternalPermissionService;
+import fi.vm.sade.kayttooikeus.enumeration.OrderByHenkilohaku;
+import fi.vm.sade.kayttooikeus.repositories.criteria.OrganisaatioHenkiloCriteria;
 import fi.vm.sade.kayttooikeus.repositories.dto.HenkilohakuResultDto;
-import fi.vm.sade.kayttooikeus.service.*;
+import fi.vm.sade.kayttooikeus.service.HenkiloService;
+import fi.vm.sade.kayttooikeus.service.IdentificationService;
+import fi.vm.sade.kayttooikeus.service.KayttajatiedotService;
 import fi.vm.sade.kayttooikeus.service.LdapSynchronizationService.LdapSynchronizationType;
+import fi.vm.sade.kayttooikeus.service.OrganisaatioHenkiloService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Authorization;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.prepost.PostAuthorize;
-
-import org.springframework.validation.annotation.Validated;
 
 @RestController
 @RequestMapping("/henkilo")
@@ -184,7 +185,8 @@ public class HenkiloController {
     @ApiOperation(value = "UI:ta varten tehty mahdollisesti HIDAS hakurajapinta. EI tarkoitettu palveluiden käyttöön. Muutosaltis.",
             notes = "Palauttaa suppean setin henkilöiden tietoja annetuilla hakukriteereillä. Toimii eri tavalla eri käyttäjäryhmille! " +
                     "(rekisterinpitäjä, OPH:n virkaiilja, muu virkailija) Hakua rajoitetaan näille ryhmille joten ei tarvitse " +
-                    "erillisiä käyttöoikeuksia.")
+                    "erillisiä käyttöoikeuksia. Hakutuloksen maksimikoko saattaa olla 100 tai 101 käyttäjätunnuksella " +
+                    "haun takia.")
     public List<HenkilohakuResultDto> henkilohaku(@Validated @RequestBody HenkilohakuCriteriaDto henkilohakuCriteriaDto,
                                                   @RequestParam(defaultValue = "0") Long offset,
                                                   @RequestParam(required = false) OrderByHenkilohaku orderBy) {

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/HenkiloHibernateRepository.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/HenkiloHibernateRepository.java
@@ -31,6 +31,9 @@ public interface HenkiloHibernateRepository extends BaseRepository<Henkilo> {
      */
     Set<String> findOidsBySamaOrganisaatio(String henkiloOid, OrganisaatioHenkiloCriteria criteria);
 
+    List<HenkilohakuResultDto> findByUsername(HenkiloCriteria criteria,
+                                              Long offset);
+
     List<HenkilohakuResultDto> findByCriteria(HenkiloCriteria criteria, Long offset, List<OrderSpecifier> orderBy);
 
     /**

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/criteria/HenkiloCriteria.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/criteria/HenkiloCriteria.java
@@ -52,12 +52,13 @@ public class HenkiloCriteria {
         }
         if (StringUtils.hasLength(this.nameQuery)) {
             BooleanBuilder predicate = new BooleanBuilder();
-            Arrays.stream(this.nameQuery.split(" ")).forEach(queryPart ->
+            Arrays.stream(this.nameQuery.toLowerCase().split(" ")).forEach(queryPart ->
                     predicate.or(Expressions.anyOf(
-                            henkilo.etunimetCached.containsIgnoreCase(queryPart),
-                            henkilo.sukunimiCached.containsIgnoreCase(queryPart)
+                            // By using contains query can't use B-tree index
+                            henkilo.etunimetCached.startsWithIgnoreCase(queryPart),
+                            henkilo.sukunimiCached.startsWithIgnoreCase(queryPart)
                     )));
-            predicate.or(Expressions.anyOf(henkilo.oidHenkilo.eq(this.nameQuery), henkilo.kayttajatiedot.username.eq(this.nameQuery)));
+            predicate.or(henkilo.oidHenkilo.eq(this.nameQuery));
             builder.and(predicate);
         }
         // Organisaatiohenkilo

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/impl/HenkiloRepositoryImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/impl/HenkiloRepositoryImpl.java
@@ -102,7 +102,7 @@ public class HenkiloRepositoryImpl extends BaseRepositoryImpl<Henkilo> implement
         QKayttajatiedot qKayttajatiedot = QKayttajatiedot.kayttajatiedot;
 
         List<Tuple> fetchByUsernameResult = new ArrayList<>();
-        if (StringUtils.hasLength(criteria.getNameQuery())) {
+        if (StringUtils.hasLength(criteria.getNameQuery()) && (offset == null || offset == 0L)) {
             // Should return 0 or 1 results since username is unique.
             fetchByUsernameResult = jpa().from(qHenkilo)
                     .innerJoin(qHenkilo.kayttajatiedot, qKayttajatiedot)

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/util/HenkilohakuBuilder.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/util/HenkilohakuBuilder.java
@@ -55,10 +55,15 @@ public class HenkilohakuBuilder {
 
     // Find nimi, kayttajatunnus and oidHenkilo
     public HenkilohakuBuilder search(Long offset, OrderByHenkilohaku orderBy) {
-        this.henkilohakuResultDtoList = this.henkiloHibernateRepository
-                .findByCriteria(this.mapper.map(this.henkilohakuCriteriaDto, HenkiloCriteria.class),
+        // Because jpaquery limitations this can't be done with subqueries and union all.
+        // This needs to be done in 2 queries because postgres query planner can't optimise it correctly because of
+        // kayttajatiedot outer join and where or combination.
+        HenkiloCriteria henkiloCriteria = this.mapper.map(this.henkilohakuCriteriaDto, HenkiloCriteria.class);
+        this.henkilohakuResultDtoList = this.henkiloHibernateRepository.findByUsername(henkiloCriteria, offset);
+        this.henkilohakuResultDtoList.addAll(this.henkiloHibernateRepository
+                .findByCriteria(henkiloCriteria,
                         offset,
-                        orderBy != null ? orderBy.getValue() : null);
+                        orderBy != null ? orderBy.getValue() : null));
         return this;
     }
 


### PR DESCRIPTION
- Kahteen eri hakuun koska postgres query planner ei osaa käyttää indeksejä nykyisessä haussa käyttäjänimille
- Muutentaan hakua paremmin käyttämään indeksejä