### PR TITLE
Kjhh 1244 omien kutsujen käyttäminen

### DIFF
--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/KutsuService.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/KutsuService.java
@@ -15,8 +15,18 @@ import java.util.List;
 public interface KutsuService {
     List<KutsuReadDto> listKutsus(KutsuOrganisaatioOrder sortBy, Sort.Direction direction, KutsuCriteria kutsuListCriteria, Long offset, Long amount);
 
+    /**
+     * Uuden kutsun luominen
+     * @param dto kutsun luomiseen
+     * @return Luodun kutsun id
+     */
     long createKutsu(KutsuCreateDto dto);
 
+    /**
+     * Kutsun hakeminen id:llä
+     * @param id kutsun id
+     * @return kutsu halutulla id:llä
+     */
     KutsuReadDto getKutsu(Long id);
 
     /**
@@ -26,11 +36,32 @@ public interface KutsuService {
      */
     void renewKutsu(long id);
 
+    /**
+     * Merkitsee kutsun tilan poistetuksi. Ei fyysisesti poista mitään.
+     * @param id poistettavan kutsun id
+     * @return poistetun kutsun id
+     */
     Kutsu deleteKutsu(long id);
 
+    /**
+     * Palauttaa kutsun väliaikaisen kutsutokenin perusteella
+     * @param temporaryToken käyttäjän vahvan tunnistuksen jälkeen generoitu väliaikainen kutsutoken
+     * @return tokenia vastaava kutsu
+     */
     KutsuReadDto getByTemporaryToken(String temporaryToken);
 
+    /**
+     * Henkilön luominen väliaikaisella kutsutokenilla
+     * @param temporaryToken token generoitu kutsulle vahvan tunnistuksen jälkeen
+     * @param henkiloCreateByKutsuDto haluttu henkilö
+     * @return Luodun henkilön oid
+     */
     String createHenkilo(String temporaryToken, HenkiloCreateByKutsuDto henkiloCreateByKutsuDto);
 
+    /**
+     * Päivittää haka tunnisteen kutsuun
+     * @param temporaryToken käyttäjän vahvan tunnistuksen jälkeen generoitu väliaikainen kutsutoken
+     * @param kutsuUpdateDto haka tunnisteen sisältävä dto
+     */
     void updateHakaIdentifierToKutsu(String temporaryToken, KutsuUpdateDto kutsuUpdateDto);
 }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KutsuServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KutsuServiceImpl.java
@@ -19,6 +19,7 @@ import fi.vm.sade.kayttooikeus.repositories.OrganisaatioHenkiloRepository;
 import fi.vm.sade.kayttooikeus.repositories.criteria.KutsuCriteria;
 import fi.vm.sade.kayttooikeus.repositories.dto.HenkiloCreateByKutsuDto;
 import fi.vm.sade.kayttooikeus.service.*;
+import fi.vm.sade.kayttooikeus.service.exception.DataInconsistencyException;
 import fi.vm.sade.kayttooikeus.service.exception.ForbiddenException;
 import fi.vm.sade.kayttooikeus.service.exception.NotFoundException;
 import fi.vm.sade.kayttooikeus.service.external.OppijanumerorekisteriClient;
@@ -239,7 +240,7 @@ public class KutsuServiceImpl implements KutsuService {
         // Create or update credentials and add privileges if hetu not same as kutsu creator
         final String kutsujaOid = kutsuByToken.getKutsuja();
         HenkiloPerustietoDto kutsuja = this.oppijanumerorekisteriClient.getHenkilonPerustiedot(kutsujaOid)
-                .orElseThrow(() -> new NotFoundException("Current user not found with oid " + kutsujaOid));
+                .orElseThrow(() -> new DataInconsistencyException("Current user not found with oid " + kutsujaOid));
         if (StringUtils.isEmpty(kutsuja.getHetu()) || !kutsuByToken.getHetu().equals(kutsuja.getHetu())) {
             this.createOrUpdateCredentialsAndPrivileges(henkiloCreateByKutsuDto, kutsuByToken, henkiloOid);
         }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KutsuServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KutsuServiceImpl.java
@@ -100,6 +100,12 @@ public class KutsuServiceImpl implements KutsuService {
             }
             this.kayttooikeusryhmaLimitationsAreValid(kutsuCreateDto.getOrganisaatiot());
         }
+        // This is redundant after every virkailija has been strongly identified
+        final String currentUserOid = this.permissionCheckerService.getCurrentUserOid();
+        HenkiloDto currentUser = this.oppijanumerorekisteriClient.getHenkiloByOid(currentUserOid);
+        if (StringUtils.isEmpty(currentUser.getHetu()) || !currentUser.isYksiloityVTJ()) {
+            throw new ForbiddenException("To create new invitation user needs to have hetu and be identified from VTJ");
+        }
 
         final Kutsu newKutsu = mapper.map(kutsuCreateDto, Kutsu.class);
 

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KutsuServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KutsuServiceImpl.java
@@ -237,10 +237,10 @@ public class KutsuServiceImpl implements KutsuService {
         henkilo.setVahvastiTunnistettu(true);
 
         // Create or update credentials and add privileges if hetu not same as kutsu creator
-        final String currentUserOid = this.permissionCheckerService.getCurrentUserOid();
-        HenkiloPerustietoDto currentUser = this.oppijanumerorekisteriClient.getHenkilonPerustiedot(currentUserOid)
-                .orElseThrow(() -> new NotFoundException("Current user not found with oid " + currentUserOid));
-        if (StringUtils.isEmpty(currentUser.getHetu()) || !kutsuByToken.getHetu().equals(currentUser.getHetu())) {
+        final String kutsujaOid = kutsuByToken.getKutsuja();
+        HenkiloPerustietoDto kutsuja = this.oppijanumerorekisteriClient.getHenkilonPerustiedot(kutsujaOid)
+                .orElseThrow(() -> new NotFoundException("Current user not found with oid " + kutsujaOid));
+        if (StringUtils.isEmpty(kutsuja.getHetu()) || !kutsuByToken.getHetu().equals(kutsuja.getHetu())) {
             this.createOrUpdateCredentialsAndPrivileges(henkiloCreateByKutsuDto, kutsuByToken, henkiloOid);
         }
 

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/it/KutsuServiceTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/it/KutsuServiceTest.java
@@ -466,9 +466,8 @@ public class KutsuServiceTest extends AbstractServiceIntegrationTest {
     }
 
     @Test
-    @WithMockUser("1.2.3.4.5")
     public void createHenkilo() {
-        given(this.oppijanumerorekisteriClient.getHenkilonPerustiedot(eq("1.2.3.4.5")))
+        given(this.oppijanumerorekisteriClient.getHenkilonPerustiedot(eq("1.2.3.4.1")))
                 .willReturn(Optional.of(HenkiloPerustietoDto.builder().hetu("valid hetu").build()));
         Kutsu kutsu = populate(KutsuPopulator.kutsu("arpa", "kuutio", "arpa@kuutio.fi")
                 .temporaryToken("123")
@@ -509,7 +508,7 @@ public class KutsuServiceTest extends AbstractServiceIntegrationTest {
     @Test
     @WithMockUser("1.2.3.4.5")
     public void createHenkiloWhenKutsuCreatorHetuMatches() {
-        given(this.oppijanumerorekisteriClient.getHenkilonPerustiedot(eq("1.2.3.4.5")))
+        given(this.oppijanumerorekisteriClient.getHenkilonPerustiedot(eq("1.2.3.4.1")))
                 .willReturn(Optional.of(HenkiloPerustietoDto.builder().hetu("valid hetu").build()));
         Kutsu kutsu = populate(KutsuPopulator.kutsu("arpa", "kuutio", "arpa@kuutio.fi")
                 .temporaryToken("123")
@@ -538,9 +537,8 @@ public class KutsuServiceTest extends AbstractServiceIntegrationTest {
 
     // Existing henkilo username changes to the new one
     @Test
-    @WithMockUser("1.2.3.4.5")
     public void createHenkiloHetuExistsKayttajatiedotExists() {
-        given(this.oppijanumerorekisteriClient.getHenkilonPerustiedot(eq("1.2.3.4.5")))
+        given(this.oppijanumerorekisteriClient.getHenkilonPerustiedot(eq("1.2.3.4.1")))
                 .willReturn(Optional.of(HenkiloPerustietoDto.builder().hetu("valid hetu").build()));
         Kutsu kutsu = populate(KutsuPopulator.kutsu("arpa", "kuutio", "arpa@kuutio.fi")
                 .temporaryToken("123")
@@ -586,9 +584,8 @@ public class KutsuServiceTest extends AbstractServiceIntegrationTest {
     }
 
     @Test
-    @WithMockUser("1.2.3.4.5")
     public void createHenkiloWithHakaIdentifier() {
-        given(this.oppijanumerorekisteriClient.getHenkilonPerustiedot(eq("1.2.3.4.5")))
+        given(this.oppijanumerorekisteriClient.getHenkilonPerustiedot(eq("1.2.3.4.1")))
                 .willReturn(Optional.of(HenkiloPerustietoDto.builder().hetu("valid hetu").build()));
         Kutsu kutsu = populate(KutsuPopulator.kutsu("arpa", "kuutio", "arpa@kuutio.fi")
                 .hakaIdentifier("!haka%Identifier1/")
@@ -634,9 +631,8 @@ public class KutsuServiceTest extends AbstractServiceIntegrationTest {
 
     // Another haka identifier will be added to an existing user credentials
     @Test
-    @WithMockUser("1.2.3.4.5")
     public void createHenkiloWithHakaIdentifierHetuExists() {
-        given(this.oppijanumerorekisteriClient.getHenkilonPerustiedot(eq("1.2.3.4.5")))
+        given(this.oppijanumerorekisteriClient.getHenkilonPerustiedot(eq("1.2.3.4.1")))
                 .willReturn(Optional.of(HenkiloPerustietoDto.builder().hetu("valid hetu").build()));
         Kutsu kutsu = populate(KutsuPopulator.kutsu("arpa", "kuutio", "arpa@kuutio.fi")
                 .hakaIdentifier("!haka%Identifier1/")


### PR DESCRIPTION
- Estää hetuttomia ja vtj-yksilöimättömiä virkailijoita luomasta kutsuja
- Ei kutsun henkilöä luodessa lisää uusia oikeuksia jos hetu on sama