### PR TITLE
KJHH-1543: Update to spring boot 2.1.1

### DIFF
--- a/kayttooikeus-service/src/main/resources/db/migration/V20190108104646838__clear_sessions.sql
+++ b/kayttooikeus-service/src/main/resources/db/migration/V20190108104646838__clear_sessions.sql
@@ -1,0 +1,3 @@
+-- Jokin muuttui binäärissä spring bootin version noustessa jolloin vanhat sessiot eivät ole enää valideja
+delete from spring_session_attributes ;
+delete from spring_session;

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/config/security/UserDetailsServiceImplTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/config/security/UserDetailsServiceImplTest.java
@@ -40,7 +40,7 @@ public class UserDetailsServiceImplTest extends AbstractServiceIntegrationTest {
         kayttajatiedotService.create("oid123", new KayttajatiedotCreateDto(kayttajatunnus),
                 LdapSynchronizationService.LdapSynchronizationType.NORMAL);
         UserDetails userDetails = userDetailsService.loadUserByUsername(kayttajatunnus);
-        assertThat(userDetails).extracting(UserDetails::getUsername).containsExactly("oid123");
+        assertThat(userDetails).extracting(UserDetails::getUsername).isEqualTo("oid123");
         assertThat(userDetails.getAuthorities()).isEmpty();
     }
 

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/VahvaTunnistusServiceTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/VahvaTunnistusServiceTest.java
@@ -85,7 +85,7 @@ public class VahvaTunnistusServiceTest extends AbstractServiceIntegrationTest {
 
         assertThat(responseDto)
                 .extracting(VahvaTunnistusResponseDto::getAuthToken)
-                .isNotEmpty();
+                .isNotNull();
         assertThat(tunnistusTokenRepository.findByLoginToken(loginToken))
                 .map(TunnistusToken::getKaytetty)
                 .isNotEmpty();
@@ -117,7 +117,7 @@ public class VahvaTunnistusServiceTest extends AbstractServiceIntegrationTest {
 
         assertThat(responseDto)
                 .extracting(VahvaTunnistusResponseDto::getAuthToken)
-                .isNotEmpty();
+                .isNotNull();
         assertThat(tunnistusTokenRepository.findByLoginToken(loginToken))
                 .map(TunnistusToken::getKaytetty)
                 .isNotEmpty();

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/it/KayttajatiedotServiceTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/it/KayttajatiedotServiceTest.java
@@ -132,7 +132,7 @@ public class KayttajatiedotServiceTest extends AbstractServiceIntegrationTest {
         assertThatThrownBy(() -> kayttajatiedotService.getByUsernameAndPassword("user2", "pass2"))
                 .isInstanceOf(UnauthorizedException.class);
         KayttajatiedotReadDto readDto = kayttajatiedotService.getByUsernameAndPassword("USER2", "IFuRzDC5+aYLSSqE");
-        assertThat(readDto).extracting(KayttajatiedotReadDto::getUsername).containsExactly("user2");
+        assertThat(readDto).extracting(KayttajatiedotReadDto::getUsername).isEqualTo("user2");
 
         // käyttäjä on passivoitu
         henkiloService.passivoi("oid2", "oid1");

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.1.RELEASE</version>
     </parent>
 
     <modules>


### PR DESCRIPTION
- SpringMvcTestit sisältävät nyt spring security filtterin jolloin testeihin tarvitaan lisää luokkia
- Tyhjentää vanhat sessiot