### PR TITLE
Kosken arkaluontoisten tietojen käyttöoikeuksia

### DIFF
--- a/kayttooikeus-service/src/main/resources/db/migration/V20190128155053000__koski_arkaluontoisia_kayttooikeuksia.sql
+++ b/kayttooikeus-service/src/main/resources/db/migration/V20190128155053000__koski_arkaluontoisia_kayttooikeuksia.sql
@@ -1,0 +1,9 @@
+SELECT insertkayttooikeus('KOSKI', 'LUOTTAMUKSELLINEN_KELA_SUPPEA', 'Kelan suppeat arkaluontoisten Koski-tietojen katseluoikeudet');
+SELECT insertkayttooikeus('KOSKI', 'LUOTTAMUKSELLINEN_KELA_LAAJA', 'Kelan laajat arkaluontoisten Koski-tietojen katseluoikeudet');
+
+BEGIN;
+  UPDATE text SET text = 'Kaikkien arkaluontoisten Koski-tietojen katseluoikeudet' WHERE textgroup_id = (
+    SELECT textgroup_id FROM kayttooikeus WHERE rooli = 'LUOTTAMUKSELLINEN' AND palvelu_id = (SELECT id FROM palvelu WHERE name = 'KOSKI')
+  );
+  UPDATE kayttooikeus SET rooli = 'LUOTTAMUKSELLINEN_KAIKKI_TIEDOT' WHERE rooli = 'LUOTTAMUKSELLINEN' AND palvelu_id = (SELECT id FROM palvelu WHERE name = 'KOSKI');
+COMMIT;


### PR DESCRIPTION
- Lisää Kelalle kaksi käyttöoikeutta (suppeat ja laajat oikeudet)
- Nimeää vanhan kaikkiin oikeuttavan käyttöoikeuden uudelleen siten, että
  nimestä käy käyttötarkoitus ilmi paremmin