### PR TITLE
KJHH-1519: kayttooikeusryhma rajoite

### DIFF
--- a/kayttooikeus-api/src/main/java/fi/vm/sade/kayttooikeus/dto/KayttoOikeusRyhmaDto.java
+++ b/kayttooikeus-api/src/main/java/fi/vm/sade/kayttooikeus/dto/KayttoOikeusRyhmaDto.java
@@ -18,12 +18,15 @@ public class KayttoOikeusRyhmaDto implements Serializable, LocalizableDto {
 
     private Long id;
     private String tunniste;
+    // Not used anywhere
+    @Deprecated
     private String rooliRajoite;
     private List<OrganisaatioViiteDto> organisaatioViite = new ArrayList<>();
     private TextGroupDto nimi;
     private TextGroupDto kuvaus;
     private boolean passivoitu;
     private boolean ryhmaRestriction;
+    private KayttajaTyyppi sallittuKayttajatyyppi;
 
     public void setNimiId(Long id) {
         this.nimi = localizeLaterById(id);

--- a/kayttooikeus-api/src/main/java/fi/vm/sade/kayttooikeus/dto/KayttoOikeusRyhmaModifyDto.java
+++ b/kayttooikeus-api/src/main/java/fi/vm/sade/kayttooikeus/dto/KayttoOikeusRyhmaModifyDto.java
@@ -23,10 +23,13 @@ public class KayttoOikeusRyhmaModifyDto {
     @Valid
     private List<PalveluRooliModifyDto> palvelutRoolit;
     private List<String> organisaatioTyypit;
+    // Not used anywhere
+    @Deprecated
     private String rooliRajoite;
     private List<Long> slaveIds;
     @NotNull
     private boolean ryhmaRestriction;
+    private KayttajaTyyppi sallittuKayttajatyyppi;
 
 
     /**

--- a/kayttooikeus-api/src/main/java/fi/vm/sade/kayttooikeus/dto/KutsuCreateDto.java
+++ b/kayttooikeus-api/src/main/java/fi/vm/sade/kayttooikeus/dto/KutsuCreateDto.java
@@ -1,7 +1,6 @@
 package fi.vm.sade.kayttooikeus.dto;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Email;
@@ -13,6 +12,9 @@ import java.util.Set;
 
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class KutsuCreateDto {
     @NotEmpty
     private String etunimi;

--- a/kayttooikeus-api/src/main/java/fi/vm/sade/kayttooikeus/dto/MyonnettyKayttoOikeusDto.java
+++ b/kayttooikeus-api/src/main/java/fi/vm/sade/kayttooikeus/dto/MyonnettyKayttoOikeusDto.java
@@ -9,6 +9,11 @@ import java.util.stream.Stream;
 
 import static fi.vm.sade.kayttooikeus.dto.TextGroupDto.localizeLaterById;
 
+/**
+ * Sisältää käyttöoikeusryhmän tiedot sekä käyttäjän voimassa olevan käyttöoikeuden tiedot jos käyttäjä voi myöntää
+ * tämän käyttöoikeusryhmän.
+ * Tätä käytetään myös vanhojen käyttöoikeuksien listaamiseen annettuun organisaatioon.
+ */
 @Setter
 @Getter
 @ToString
@@ -30,9 +35,11 @@ public class MyonnettyKayttoOikeusDto implements LocalizableDto, Serializable{
     private LocalDateTime kasitelty;
     private String kasittelijaOid;
     private String kasittelijaNimi;
+    // Voiko käyttäjä myöntää tämän käyttöoikeuden (ryhmaId) tähän organisaatioon (organisaatioOid)
     private boolean selected;
     private boolean removed;
     private String muutosSyy;
+    private KayttajaTyyppi sallittuKayttajatyyppi;
 
     public void setRyhmaNamesId(Long ryhmaNamesId) {
         this.ryhmaNames = localizeLaterById(ryhmaNamesId);

--- a/kayttooikeus-api/src/main/java/fi/vm/sade/kayttooikeus/dto/UpdateHaettuKayttooikeusryhmaDto.java
+++ b/kayttooikeus-api/src/main/java/fi/vm/sade/kayttooikeus/dto/UpdateHaettuKayttooikeusryhmaDto.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 public class UpdateHaettuKayttooikeusryhmaDto {
 
+    // Haettu käyttöoikeusryhmä id
     private Long id;
 
     @Pattern(regexp = "^(MYONNETTY|HYLATTY)$", message = "invalid.kayttooikeudentila")

--- a/kayttooikeus-domain/src/main/java/fi/vm/sade/kayttooikeus/model/KayttoOikeusRyhma.java
+++ b/kayttooikeus-domain/src/main/java/fi/vm/sade/kayttooikeus/model/KayttoOikeusRyhma.java
@@ -1,5 +1,6 @@
 package fi.vm.sade.kayttooikeus.model;
 
+import fi.vm.sade.kayttooikeus.dto.KayttajaTyyppi;
 import lombok.*;
 import org.hibernate.annotations.BatchSize;
 
@@ -43,12 +44,19 @@ public class KayttoOikeusRyhma extends IdentifiableAndVersionedEntity {
     
     @Column(name = "hidden", nullable = false)
     private boolean passivoitu;
-    
+
+    // Not used anywhere
+    @Deprecated
     @Column(name = "rooli_rajoite")
     private String rooliRajoite;
 
     @Column(name = "ryhma_restriction", nullable = false)
     private boolean ryhmaRestriction;
+
+    // Käyttäjätyyppi jolle tämän käyttöoikeusryhmän voi myöntää. Sallittu kaikille jos ei asetettu.
+    @Column(name = "allowed_usertype")
+    @Enumerated(EnumType.STRING)
+    private KayttajaTyyppi sallittuKayttajatyyppi;
 
     public void addOrganisaatioViite(OrganisaatioViite organisaatioViite) {
         organisaatioViite.setKayttoOikeusRyhma(this);
@@ -68,6 +76,10 @@ public class KayttoOikeusRyhma extends IdentifiableAndVersionedEntity {
             this.kayttoOikeus = new HashSet<>();
         }
         this.kayttoOikeus.add(kayttoOikeus);
+    }
+
+    public boolean isSallittuKayttajatyypilla(KayttajaTyyppi kayttajaTyyppi) {
+        return this.getSallittuKayttajatyyppi() == null || this.getSallittuKayttajatyyppi().equals(kayttajaTyyppi);
     }
 
 }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/mapper/KayttoOikeusRyhmaConverter.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/mapper/KayttoOikeusRyhmaConverter.java
@@ -26,7 +26,8 @@ public class KayttoOikeusRyhmaConverter extends CustomConverter<KayttoOikeusRyhm
                 .organisaatioViite(source.getOrganisaatioViite().stream().map(organisaatioViite -> OrganisaatioViiteDto.builder()
                         .id(organisaatioViite.getId())
                         .organisaatioTyyppi(organisaatioViite.getOrganisaatioTyyppi())
-                        .build()).collect(Collectors.toList()));
+                        .build()).collect(Collectors.toList()))
+                .sallittuKayttajatyyppi(source.getSallittuKayttajatyyppi());
 
         if (source.getKuvaus() != null) {
             destinationBuilder.kuvaus(new TextGroupDto(source.getKuvaus().getId()));

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/mapper/KutsuCreateKayttoOikeusRyhmaConverter.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/mapper/KutsuCreateKayttoOikeusRyhmaConverter.java
@@ -3,6 +3,7 @@ package fi.vm.sade.kayttooikeus.config.mapper;
 import fi.vm.sade.kayttooikeus.dto.KutsuCreateDto;
 import fi.vm.sade.kayttooikeus.model.KayttoOikeusRyhma;
 import fi.vm.sade.kayttooikeus.repositories.KayttoOikeusRyhmaRepository;
+import fi.vm.sade.kayttooikeus.repositories.KayttoOikeusRyhmaRepositoryCustom;
 import ma.glasnost.orika.CustomConverter;
 import ma.glasnost.orika.MappingContext;
 import ma.glasnost.orika.metadata.Type;

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/controller/AnomusController.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/controller/AnomusController.java
@@ -64,7 +64,7 @@ public class AnomusController {
 
 
     @ApiOperation("Hyväksyy tai hylkää haetun käyttöoikeusryhmän")
-    // Organisation access validated on server layer
+    // Organisation access validated on service layer
     @PreAuthorize("hasAnyRole('ROLE_APP_KAYTTOOIKEUS_CRUD',"
             + "'ROLE_APP_KAYTTOOIKEUS_REKISTERINPITAJA')")
     @RequestMapping(value = "", method = RequestMethod.PUT)
@@ -74,7 +74,7 @@ public class AnomusController {
     }
 
     @ApiOperation("Myöntää halutut käyttöoikeusryhmät käyttäjälle haluttuun organisaatioon")
-    // Organisation access validated on server layer
+    // Organisation access validated on service layer
     @PreAuthorize("hasAnyRole('ROLE_APP_KAYTTOOIKEUS_CRUD',"
             + "'ROLE_APP_KAYTTOOIKEUS_REKISTERINPITAJA')")
     @RequestMapping(value = "/{oidHenkilo}/{organisaatioOid}", method = RequestMethod.PUT)

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/KayttoOikeusRyhmaRepository.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/KayttoOikeusRyhmaRepository.java
@@ -1,22 +1,13 @@
 package fi.vm.sade.kayttooikeus.repositories;
 
-import com.querydsl.core.Tuple;
-import fi.vm.sade.kayttooikeus.dto.KayttoOikeusRyhmaDto;
 import fi.vm.sade.kayttooikeus.model.KayttoOikeusRyhma;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Optional;
+@Repository
+@Transactional(propagation = Propagation.MANDATORY)
+public interface KayttoOikeusRyhmaRepository extends KayttoOikeusRyhmaRepositoryCustom, CrudRepository<KayttoOikeusRyhma, Long> {
 
-public interface KayttoOikeusRyhmaRepository extends BaseRepository<KayttoOikeusRyhma> {
-    List<KayttoOikeusRyhmaDto> findByIdList(List<Long> idList);
-
-    Optional<KayttoOikeusRyhma> findByRyhmaId(Long id);
-
-    Boolean ryhmaNameFiExists(String ryhmaNameFi);
-
-    List<KayttoOikeusRyhmaDto> listAll();
-
-    List<Tuple> findOrganisaatioOidAndRyhmaIdByHenkiloOid(String oid);
-
-    List<KayttoOikeusRyhmaDto> findKayttoOikeusRyhmasByKayttoOikeusIds(List<Long> kayttoOikeusIds);
 }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/KayttoOikeusRyhmaRepositoryCustom.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/KayttoOikeusRyhmaRepositoryCustom.java
@@ -1,0 +1,23 @@
+package fi.vm.sade.kayttooikeus.repositories;
+
+import com.querydsl.core.Tuple;
+import fi.vm.sade.kayttooikeus.dto.KayttoOikeusRyhmaDto;
+import fi.vm.sade.kayttooikeus.model.KayttoOikeusRyhma;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface KayttoOikeusRyhmaRepositoryCustom {
+    List<KayttoOikeusRyhmaDto> findByIdList(List<Long> idList);
+
+    Optional<KayttoOikeusRyhma> findByRyhmaId(Long id);
+
+    Boolean ryhmaNameFiExists(String ryhmaNameFi);
+
+    List<KayttoOikeusRyhmaDto> listAll();
+
+    List<Tuple> findOrganisaatioOidAndRyhmaIdByHenkiloOid(String oid);
+
+    List<KayttoOikeusRyhmaDto> findKayttoOikeusRyhmasByKayttoOikeusIds(List<Long> kayttoOikeusIds);
+}

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/KayttoOikeusRyhmaTapahtumaHistoriaRepository.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/KayttoOikeusRyhmaTapahtumaHistoriaRepository.java
@@ -5,5 +5,11 @@ import fi.vm.sade.kayttooikeus.dto.MyonnettyKayttoOikeusDto;
 import java.util.List;
 
 public interface KayttoOikeusRyhmaTapahtumaHistoriaRepository {
+    /**
+     * Listaa henkilön vanhat oikeudet annettuun organisaatioon
+     * @param henkiloOid Henkilön oid
+     * @param organisaatioOid Organisaation oid
+     * @return Lista vanhoja oikeuksia
+     */
     List<MyonnettyKayttoOikeusDto> findByHenkiloInOrganisaatio(String henkiloOid, String organisaatioOid);
 }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/KayttoOikeusService.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/KayttoOikeusService.java
@@ -26,8 +26,21 @@ public interface KayttoOikeusService {
 
     List<KayttoOikeusRyhmaDto> listPossibleRyhmasByOrganization(String organisaatioOid);
 
+    /**
+     * Listaa käyttöoikeusryhmät jotka käyttäjä voi myöntää annetulle henkilölle annettuun organisaatioon.
+     * @param oid Henkilön jolle mahdolliset käyttöoikeudet voidaan myöntää
+     * @param organisaatioOid Organisaatio johon mahdolliset käyttöoikeudet voidaan myöntää
+     * @param currentUserOid Käyttäjä, joka myöntää oikeudet
+     * @return Lista myönnettäviä käyttöoikeusryhmiä
+     */
     List<MyonnettyKayttoOikeusDto> listMyonnettyKayttoOikeusRyhmasMergedWithHenkilos(String oid, String organisaatioOid, String currentUserOid);
 
+    /**
+     * Listaa kaikki käyttöoikeusryhmät, mukaanlukien vanhat oikeudet, annetulle henkilölle kyseiseen organisaatioon
+     * @param oid Henkilön oid jonka oikeuksia palautetaan
+     * @param organisaatioOid Organisaation oid johon rajataan palautettavat oikeudet
+     * @return Lista käyttäjän oikeuksia
+     */
     List<MyonnettyKayttoOikeusDto> listMyonnettyKayttoOikeusRyhmasByHenkiloAndOrganisaatio(String oid, String organisaatioOid);
 
     KayttoOikeusRyhmaDto findKayttoOikeusRyhma(long id);

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/KayttooikeusAnomusService.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/KayttooikeusAnomusService.java
@@ -17,19 +17,35 @@ public interface KayttooikeusAnomusService {
 
     List<HaettuKayttooikeusryhmaDto> listHaetutKayttoOikeusRyhmat(AnomusCriteria criteria, Long limit, Long offset, OrderByAnomus orderBy);
 
+    /**
+     * Myöntää tai hylkää haetun käyttöoikeusryhmän anomukselta. Myönnettäessä oikeus lisätään anomukselle myönnettyihin
+     * oikeuksiin ja poistetaan anomukselta. Hylättäessä haettu käyttöoikeusryhmä vain poistetaan anomukselta.
+     * @param updateHaettuKayttooikeusryhmaDto Haetun käyttöoikeusryhmän käsittelytiedot
+     */
     void updateHaettuKayttooikeusryhma(UpdateHaettuKayttooikeusryhmaDto updateHaettuKayttooikeusryhmaDto);
 
+    /**
+     * Suora käyttöoikeuksien myöntäminen henkilölle haluttuun organisaatioon.
+     * @param anojaOid Henkilön oid jolle oikeudet myönnetään
+     * @param organisaatioOid Organisaation oid johon oikeudet myönnetään
+     * @param updateHaettuKayttooikeusryhmaDtoList Myönnettävät oikeudet
+     */
     void grantKayttooikeusryhma(String anojaOid, String organisaatioOid, List<GrantKayttooikeusryhmaDto> updateHaettuKayttooikeusryhmaDtoList);
 
-    void grantKayttooikeusryhmaAsAdminWithoutPermissionCheck(String anoja,
-                                                             String organisaatioOid,
-                                                             Collection<KayttoOikeusRyhma> kayttooikeusryhmas);
-
-    void grantKayttooikeusryhmaAsAdminWithoutPermissionCheck(String anoja,
-                                                             String organisaatioOid,
-                                                             LocalDate voimassaLoppuPvm,
-                                                             Collection<KayttoOikeusRyhma> kayttooikeusryhmas,
-                                                             String myontaja);
+    /**
+     * Myöntää henkilölle suoraan käyttöoikeudet ilman tarkistuksia. Oletetaan, että myönnettävät oikeudet on jo validoitu
+     * ja tätä funktiokutsua ei suorita kirjautunut käyttäjä.
+     * @param anoja Henkilön oid jolle oikeudet myönnetään
+     * @param organisaatioOid Organisaation oid johon oikeudet myönnetään
+     * @param voimassaLoppuPvm Oikeuksien sulkeutumispäivämäärä
+     * @param kayttooikeusryhmas Myönnettävät oikeudet
+     * @param myontaja Henkilön oid joka katsotaan myöntäväksi henkilöksi
+     */
+    void grantPreValidatedKayttooikeusryhma(String anoja,
+                                            String organisaatioOid,
+                                            LocalDate voimassaLoppuPvm,
+                                            Collection<KayttoOikeusRyhma> kayttooikeusryhmas,
+                                            String myontaja);
 
     Long createKayttooikeusAnomus(String anojaOid, KayttooikeusAnomusDto kayttooikeusAnomusDto);
 

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/KutsuService.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/KutsuService.java
@@ -58,6 +58,7 @@ public interface KutsuService {
      * @return Luodun henkilön oid
      */
     HenkiloUpdateDto createHenkilo(String temporaryToken, HenkiloCreateByKutsuDto henkiloCreateByKutsuDto);
+
     void addEmailToExistingHenkiloUpdateDto(String henkiloOid, String kutsuEmail, HenkiloUpdateDto henkiloUpdateDto);
 
     /**

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/EmailServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/EmailServiceImpl.java
@@ -9,6 +9,7 @@ import fi.vm.sade.kayttooikeus.model.Anomus;
 import fi.vm.sade.kayttooikeus.model.KayttoOikeusRyhma;
 import fi.vm.sade.kayttooikeus.model.Kutsu;
 import fi.vm.sade.kayttooikeus.repositories.KayttoOikeusRyhmaRepository;
+import fi.vm.sade.kayttooikeus.repositories.KayttoOikeusRyhmaRepositoryCustom;
 import fi.vm.sade.kayttooikeus.repositories.dto.ExpiringKayttoOikeusDto;
 import fi.vm.sade.kayttooikeus.service.EmailService;
 import fi.vm.sade.kayttooikeus.service.exception.NotFoundException;

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttoOikeusServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttoOikeusServiceImpl.java
@@ -236,6 +236,8 @@ public class KayttoOikeusServiceImpl extends AbstractService implements KayttoOi
         }
         kayttoOikeusRyhma.setRooliRajoite(uusiRyhma.getRooliRajoite());
 
+        kayttoOikeusRyhma.setSallittuKayttajatyyppi(uusiRyhma.getSallittuKayttajatyyppi());
+
         kayttoOikeusRyhma.getKayttoOikeus().addAll(uusiRyhma.getPalvelutRoolit().stream()
                 .map(palveluRoooliDto ->
                         ofNullable(kayttoOikeusRepository.findByRooliAndPalvelu(palveluRoooliDto.getRooli(),
@@ -301,6 +303,8 @@ public class KayttoOikeusServiceImpl extends AbstractService implements KayttoOi
         setRyhmaOrganisaatioViites(ryhmaData, kayttoOikeusRyhma);
 
         setKayttoOikeusRyhmas(ryhmaData, kayttoOikeusRyhma);
+
+        kayttoOikeusRyhma.setSallittuKayttajatyyppi(ryhmaData.getSallittuKayttajatyyppi());
     }
 
     @Override

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttoOikeusServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttoOikeusServiceImpl.java
@@ -247,7 +247,7 @@ public class KayttoOikeusServiceImpl extends AbstractService implements KayttoOi
                                     .orElseThrow(() -> new NotFoundException("palvelu not found"))
                     )))).collect(toList()));
 
-        kayttoOikeusRyhma = kayttoOikeusRyhmaRepository.persist(kayttoOikeusRyhma);
+        kayttoOikeusRyhma = kayttoOikeusRyhmaRepository.save(kayttoOikeusRyhma);
 
         // Organization limitation must be set only if the Organizatio OIDs are defined
         if (!isEmpty(uusiRyhma.getOrganisaatioTyypit())) {

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttoOikeusServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttoOikeusServiceImpl.java
@@ -434,7 +434,7 @@ public class KayttoOikeusServiceImpl extends AbstractService implements KayttoOi
 
     private List<KayttoOikeusRyhmaDto> getGrantableRyhmasWithoutOrgLimitations(String organisaatioOid, String myontajaOid) {
         // Get all master ids for current user and use them to get a list of all slave ids
-        List<Long> slaveIds =  kayttoOikeusRyhmaMyontoViiteRepository.getSlaveIdsByMasterIds(
+        List<Long> slaveIds = kayttoOikeusRyhmaMyontoViiteRepository.getSlaveIdsByMasterIds(
                 myonnettyKayttoOikeusRyhmaTapahtumaRepository.findMasterIdsByHenkilo(myontajaOid));
 
 

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttoOikeusServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttoOikeusServiceImpl.java
@@ -129,34 +129,38 @@ public class KayttoOikeusServiceImpl extends AbstractService implements KayttoOi
     @Override
     @Transactional(readOnly = true)
     public List<MyonnettyKayttoOikeusDto> listMyonnettyKayttoOikeusRyhmasMergedWithHenkilos(String henkiloOid, String organisaatioOid, String myontajaOid) {
+        // Käyttöoikeusryhmät jotka käyttäjä voi myöntää annettuun organisaatioon
         List<KayttoOikeusRyhmaDto> allRyhmas = getGrantableRyhmasWithoutOrgLimitations(organisaatioOid, myontajaOid);
         if (allRyhmas.isEmpty()){
             return Collections.emptyList();
         }
 
+        // Käyttäjän oikeudet annettuun organisaatioon
         List<MyonnettyKayttoOikeusDto> kayttoOikeusForHenkilo = myonnettyKayttoOikeusRyhmaTapahtumaRepository.findByHenkiloInOrganisaatio(henkiloOid, organisaatioOid);
         List<MyonnettyKayttoOikeusDto> all = allRyhmas.stream()
                 .map(kayttoOikeusRyhmaDto -> {
-            MyonnettyKayttoOikeusDto dto = new MyonnettyKayttoOikeusDto();
-            dto.setRyhmaId(kayttoOikeusRyhmaDto.getId());
-            dto.setRyhmaTunniste(kayttoOikeusRyhmaDto.getTunniste());
-            if (kayttoOikeusRyhmaDto.getNimi() != null) {
-                dto.setRyhmaNamesId(kayttoOikeusRyhmaDto.getNimi().getId());
-            }
-            if (kayttoOikeusRyhmaDto.getKuvaus() != null) {
-                dto.setRyhmaKuvausId(kayttoOikeusRyhmaDto.getKuvaus().getId());
-            }
-            dto.setSelected(false);
-            kayttoOikeusForHenkilo.stream()
-                    .filter(myonnettyKayttoOikeusDto -> myonnettyKayttoOikeusDto.getRyhmaId().equals(dto.getRyhmaId()))
-                    .findFirst().ifPresent(myonnettyKayttoOikeusDto -> {
-                        dto.setMyonnettyTapahtumaId(myonnettyKayttoOikeusDto.getMyonnettyTapahtumaId());
-                        dto.setAlkuPvm(myonnettyKayttoOikeusDto.getAlkuPvm());
-                        dto.setVoimassaPvm(myonnettyKayttoOikeusDto.getVoimassaPvm());
-                        dto.setSelected(true);
-                    });
-            return dto;
-        }).collect(Collectors.toList());
+                    MyonnettyKayttoOikeusDto dto = new MyonnettyKayttoOikeusDto();
+                    dto.setRyhmaId(kayttoOikeusRyhmaDto.getId());
+                    dto.setRyhmaTunniste(kayttoOikeusRyhmaDto.getTunniste());
+                    if (kayttoOikeusRyhmaDto.getNimi() != null) {
+                        dto.setRyhmaNamesId(kayttoOikeusRyhmaDto.getNimi().getId());
+                    }
+                    if (kayttoOikeusRyhmaDto.getKuvaus() != null) {
+                        dto.setRyhmaKuvausId(kayttoOikeusRyhmaDto.getKuvaus().getId());
+                    }
+                    dto.setSallittuKayttajatyyppi(kayttoOikeusRyhmaDto.getSallittuKayttajatyyppi());
+                    dto.setSelected(false);
+                    kayttoOikeusForHenkilo.stream()
+                            .filter(myonnettyKayttoOikeusDto -> myonnettyKayttoOikeusDto.getRyhmaId().equals(dto.getRyhmaId()))
+                            .findFirst()
+                            .ifPresent(myonnettyKayttoOikeusDto -> {
+                                dto.setMyonnettyTapahtumaId(myonnettyKayttoOikeusDto.getMyonnettyTapahtumaId());
+                                dto.setAlkuPvm(myonnettyKayttoOikeusDto.getAlkuPvm());
+                                dto.setVoimassaPvm(myonnettyKayttoOikeusDto.getVoimassaPvm());
+                                dto.setSelected(true);
+                            });
+                    return dto;
+                }).collect(Collectors.toList());
 
         return localizationService.localize(all);
     }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttooikeusAnomusServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttooikeusAnomusServiceImpl.java
@@ -309,7 +309,7 @@ public class KayttooikeusAnomusServiceImpl extends AbstractService implements Ka
 
         kayttoOikeusRyhmas.forEach(k -> {
             if (!k.isSallittuKayttajatyypilla(anoja.getKayttajaTyyppi())) {
-                throw new IllegalStateException(String.format("Käyttöikeusryhmää %d ei ole sallittu henkilön %s käyttäjätyypille %s", k.getId(), anoja.getOidHenkilo(), anoja.getKayttajaTyyppi()));
+                throw new IllegalStateException(String.format("Käyttöoikeusryhmää %d ei ole sallittu henkilön %s käyttäjätyypille %s", k.getId(), anoja.getOidHenkilo(), anoja.getKayttajaTyyppi()));
             }
             HaettuKayttoOikeusRyhma h = new HaettuKayttoOikeusRyhma();
             h.setKayttoOikeusRyhma(k);

--- a/kayttooikeus-service/src/main/resources/db/migration/V20190125163725041__kayttooikeusryhma_allowed_usertype.sql
+++ b/kayttooikeus-service/src/main/resources/db/migration/V20190125163725041__kayttooikeusryhma_allowed_usertype.sql
@@ -1,0 +1,2 @@
+alter table kayttooikeusryhma
+  add column allowed_usertype text;

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/repositories/KayttoOikeusRyhmaRepositoryTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/repositories/KayttoOikeusRyhmaRepositoryTest.java
@@ -177,7 +177,7 @@ public class KayttoOikeusRyhmaRepositoryTest extends AbstractRepositoryTest {
         kor.setNimi(textGroup);
         kor.getKayttoOikeus().add(oikeus);
         kor.setRooliRajoite("roolirajoite");
-        kor = kayttoOikeusRyhmaRepository.persist(kor);
+        kor = kayttoOikeusRyhmaRepository.save(kor);
 
         ryhmas = kayttoOikeusRyhmaRepository.listAll();
         assertEquals(1, ryhmas.size());

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/repositories/populate/KayttoOikeusRyhmaPopulator.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/repositories/populate/KayttoOikeusRyhmaPopulator.java
@@ -1,5 +1,6 @@
 package fi.vm.sade.kayttooikeus.repositories.populate;
 
+import fi.vm.sade.kayttooikeus.dto.KayttajaTyyppi;
 import fi.vm.sade.kayttooikeus.model.KayttoOikeus;
 import fi.vm.sade.kayttooikeus.model.KayttoOikeusRyhma;
 import fi.vm.sade.kayttooikeus.model.OrganisaatioViite;
@@ -17,6 +18,7 @@ public class KayttoOikeusRyhmaPopulator implements Populator<KayttoOikeusRyhma> 
     private Populator<TextGroup> kuvaus = Populator.constant(new TextGroup());
     private String rooliRajoite;
     private boolean ryhmaRestriction;
+    private KayttajaTyyppi sallittu;
 
     public KayttoOikeusRyhmaPopulator(String tunniste) {
         this.tunniste = tunniste;
@@ -29,6 +31,11 @@ public class KayttoOikeusRyhmaPopulator implements Populator<KayttoOikeusRyhma> 
     
     public KayttoOikeusRyhmaPopulator withOikeus(Populator<KayttoOikeus> oikeus) {
         this.oikeus.add(oikeus);
+        return this;
+    }
+
+    public KayttoOikeusRyhmaPopulator withSallittu(KayttajaTyyppi sallittu) {
+        this.sallittu = sallittu;
         return this;
     }
     
@@ -80,10 +87,13 @@ public class KayttoOikeusRyhmaPopulator implements Populator<KayttoOikeusRyhma> 
             r.setPassivoitu(passivoitu);
             r.setRooliRajoite(rooliRajoite);
             r.setRyhmaRestriction(ryhmaRestriction);
+            r.setSallittuKayttajatyyppi(sallittu);
             entityManager.persist(r);
             return r;
         });
-        
+
+        ryhma.setSallittuKayttajatyyppi(sallittu);
+
         oikeus.forEach(o -> {
             KayttoOikeus kayttoOikeus = o.apply(entityManager);
             ryhma.addKayttooikeus(kayttoOikeus);

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/EmailServiceTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/EmailServiceTest.java
@@ -6,6 +6,7 @@ import fi.vm.sade.kayttooikeus.dto.UpdateHaettuKayttooikeusryhmaDto;
 import fi.vm.sade.kayttooikeus.dto.YhteystietojenTyypit;
 import fi.vm.sade.kayttooikeus.model.*;
 import fi.vm.sade.kayttooikeus.repositories.KayttoOikeusRyhmaRepository;
+import fi.vm.sade.kayttooikeus.repositories.KayttoOikeusRyhmaRepositoryCustom;
 import fi.vm.sade.kayttooikeus.repositories.dto.ExpiringKayttoOikeusDto;
 import fi.vm.sade.kayttooikeus.service.external.OppijanumerorekisteriClient;
 import fi.vm.sade.kayttooikeus.service.external.OrganisaatioClient;

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/KayttoOikeusServiceUnitTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/KayttoOikeusServiceUnitTest.java
@@ -3,6 +3,7 @@ package fi.vm.sade.kayttooikeus.service;
 import com.google.common.collect.Lists;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
+import fi.vm.sade.kayttooikeus.dto.KayttajaTyyppi;
 import fi.vm.sade.kayttooikeus.dto.MyonnettyKayttoOikeusDto;
 import fi.vm.sade.kayttooikeus.model.QMyonnettyKayttoOikeusRyhmaTapahtuma;
 import fi.vm.sade.kayttooikeus.model.QOrganisaatioHenkilo;
@@ -73,6 +74,7 @@ public class KayttoOikeusServiceUnitTest extends AbstractServiceIntegrationTest 
                 .build();
         MyonnettyKayttoOikeusDto myonnettyKayttoOikeusDto = MyonnettyKayttoOikeusDto.builder()
                 .kasittelijaOid("1.2.3.4.1")
+                .sallittuKayttajatyyppi(KayttajaTyyppi.PALVELU)
                 .build();
         MyonnettyKayttoOikeusDto myonnettyKayttoOikeusDto2 = MyonnettyKayttoOikeusDto.builder()
                 .kasittelijaOid("1.2.3.4.2")
@@ -88,7 +90,7 @@ public class KayttoOikeusServiceUnitTest extends AbstractServiceIntegrationTest 
         List<MyonnettyKayttoOikeusDto> myonnettyKayttooikeusList = this.kayttoOikeusService
                 .listMyonnettyKayttoOikeusRyhmasByHenkiloAndOrganisaatio("1.2.3.4.5", null);
         assertThat(myonnettyKayttooikeusList)
-                .extracting(MyonnettyKayttoOikeusDto::getKasittelijaOid, MyonnettyKayttoOikeusDto::getKasittelijaNimi)
-                .containsExactlyInAnyOrder(tuple("1.2.3.4.1", "arpa kuutio"), tuple("1.2.3.4.2", "1.2.3.4.2"));
+                .extracting(MyonnettyKayttoOikeusDto::getKasittelijaOid, MyonnettyKayttoOikeusDto::getKasittelijaNimi, MyonnettyKayttoOikeusDto::getSallittuKayttajatyyppi)
+                .containsExactlyInAnyOrder(tuple("1.2.3.4.1", "arpa kuutio", KayttajaTyyppi.PALVELU), tuple("1.2.3.4.2", "1.2.3.4.2", null));
     }
 }

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/KayttoOikeusServiceUnitTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/KayttoOikeusServiceUnitTest.java
@@ -7,6 +7,7 @@ import fi.vm.sade.kayttooikeus.dto.MyonnettyKayttoOikeusDto;
 import fi.vm.sade.kayttooikeus.model.QMyonnettyKayttoOikeusRyhmaTapahtuma;
 import fi.vm.sade.kayttooikeus.model.QOrganisaatioHenkilo;
 import fi.vm.sade.kayttooikeus.repositories.KayttoOikeusRyhmaRepository;
+import fi.vm.sade.kayttooikeus.repositories.KayttoOikeusRyhmaRepositoryCustom;
 import fi.vm.sade.kayttooikeus.repositories.KayttoOikeusRyhmaTapahtumaHistoriaRepository;
 import fi.vm.sade.kayttooikeus.repositories.MyonnettyKayttoOikeusRyhmaTapahtumaRepository;
 import fi.vm.sade.kayttooikeus.service.external.OppijanumerorekisteriClient;

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/KayttooikeusAnomusServiceTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/KayttooikeusAnomusServiceTest.java
@@ -472,8 +472,8 @@ public class KayttooikeusAnomusServiceTest {
                 .willReturn(Optional.of(myonnettyKayttoOikeusRyhmaTapahtuma));
 
         KayttoOikeusRyhma grantKayttooikeusryhma = createKayttooikeusryhma(2001L);
-        this.kayttooikeusAnomusService.grantKayttooikeusryhmaAsAdminWithoutPermissionCheck("1.2.3.4.5", "1.2.0.0.1",
-                Lists.newArrayList(grantKayttooikeusryhma));
+        this.kayttooikeusAnomusService.grantPreValidatedKayttooikeusryhma("1.2.3.4.5", "1.2.0.0.1",LocalDate.now().plusYears(1),
+                Lists.newArrayList(grantKayttooikeusryhma), "1.2.3.4.1");
 
         ArgumentCaptor<MyonnettyKayttoOikeusRyhmaTapahtuma> myonnettyKayttoOikeusRyhmaTapahtumaArgumentCaptor =
                 ArgumentCaptor.forClass(MyonnettyKayttoOikeusRyhmaTapahtuma.class);

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/it/KutsuServiceTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/it/KutsuServiceTest.java
@@ -411,7 +411,8 @@ public class KutsuServiceTest extends AbstractServiceIntegrationTest {
                 .sukunimi("kutsuja")
                 .build())
                 .when(this.oppijanumerorekisteriClient).getHenkiloByOid(anyString());
-        this.kutsuService.createKutsu(new KutsuCreateDto());
+        // This kind of kutsu is not actually allowed on api.
+        this.kutsuService.createKutsu(KutsuCreateDto.builder().organisaatiot(new HashSet<>()).build());
     }
 
     // Assert that existing yhteystiedot won't be overrun

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/util/CreateUtil.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/util/CreateUtil.java
@@ -48,7 +48,7 @@ public class CreateUtil {
     public static HaettuKayttooikeusryhmaDto createHaettuKattyooikeusryhmaDto(Long haettuRyhmaId, String organisaatioOid,
                                                                                KayttoOikeudenTila tila) {
         KayttoOikeusRyhmaDto kayttoOikeusRyhmaDto = new KayttoOikeusRyhmaDto(1001L, "Kayttooikeusryhma x",
-                "10", newArrayList(), new TextGroupDto(2001L), new TextGroupDto(2002L), false, false);
+                "10", newArrayList(), new TextGroupDto(2001L), new TextGroupDto(2002L), false, false, null);
         return new HaettuKayttooikeusryhmaDto(haettuRyhmaId, createAnomusDto(organisaatioOid), kayttoOikeusRyhmaDto, LocalDateTime.now(), tila);
     }
 
@@ -58,7 +58,7 @@ public class CreateUtil {
 
     public static KayttoOikeusRyhma createKayttooikeusryhma(Long id) {
         KayttoOikeusRyhma kayttoOikeusRyhma = new KayttoOikeusRyhma("Kayttooikeusryhma x", Collections.<KayttoOikeus>emptySet(),
-                new TextGroup(), new TextGroup(), Sets.newHashSet(), false, "10", false);
+                new TextGroup(), new TextGroup(), Sets.newHashSet(), false, "10", false, null);
         kayttoOikeusRyhma.setId(id);
         return kayttoOikeusRyhma;
     }


### PR DESCRIPTION
- Toiminto käyttöoikeusryhmän merkkaamiseksi vain palvelukäyttäjille myönnettäväksi
- Estetään vain palvelukäyttäjälle tarkoitettujen käyttöoikeusryhmien myöntäminen virkailijalle anomuksissa, kutsuissa ja suorassa käyttöoikeuksien myöntämisessä
- Tällaiseen käyttöoikeusryhmään anotun oikeuden voi kuitenkin hylätä anomukselta