### PR TITLE
KJHH-1526: passiiviset koryhmat

### DIFF
--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/controller/KayttoOikeusRyhmaController.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/controller/KayttoOikeusRyhmaController.java
@@ -163,6 +163,14 @@ public class KayttoOikeusRyhmaController {
         kayttoOikeusService.passivoiKayttooikeusryhma(id);
     }
 
+    @RequestMapping(value = "/{id}/aktivoi", method = RequestMethod.PUT)
+    @PreAuthorize("hasAnyRole('ROLE_APP_KAYTTOOIKEUS_REKISTERINPITAJA')")
+    @ApiOperation(value = "Aktivoi käyttöoikeusryhmän.",
+            notes = "Aktivoi passivoidun käyttöoikeusryhmän.")
+    public void aktivoiKayttoOikeusRyhma(@PathVariable("id") Long id) {
+        this.kayttoOikeusService.aktivoiKayttooikeusryhma(id);
+    }
+
     @RequestMapping(value = "/ryhmasByKayttooikeus", method = RequestMethod.POST)
     @PreAuthorize("hasAnyRole('ROLE_APP_KAYTTOOIKEUS_KAYTTOOIKEUSRYHMIEN_LUKU',"
             + "'ROLE_APP_KAYTTOOIKEUS_REKISTERINPITAJA')")

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/controller/KayttoOikeusRyhmaController.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/controller/KayttoOikeusRyhmaController.java
@@ -33,8 +33,8 @@ public class KayttoOikeusRyhmaController {
     @PreAuthorize("isAuthenticated()")
     @ApiOperation(value = "Listaa kaikki käyttöoikeusryhmät.",
             notes = "Listaa kaikki käyttöoikeusryhmät, jotka on tallennettu henkilöhallintaan.")
-    public List<KayttoOikeusRyhmaDto> listKayttoOikeusRyhma() {
-        return kayttoOikeusService.listAllKayttoOikeusRyhmas();
+    public List<KayttoOikeusRyhmaDto> listKayttoOikeusRyhma(@RequestParam(required = false) Boolean passiiviset) {
+        return kayttoOikeusService.listAllKayttoOikeusRyhmas(passiiviset);
     }
 
     @ApiOperation(value = "Hakee henkilön käyttöoikeusryhmät organisaatioittain")
@@ -91,8 +91,9 @@ public class KayttoOikeusRyhmaController {
     @ApiOperation(value = "Hakee käyttöoikeusryhmän tiedot.",
             notes = "Hakee yhden käyttöoikeusryhmän kaikki tiedot "
                     + "annetun käyttöoikeusryhmän ID:n avulla.")
-    public KayttoOikeusRyhmaDto getKayttoOikeusRyhma(@PathVariable("id") Long id) {
-        return kayttoOikeusService.findKayttoOikeusRyhma(id);
+    public KayttoOikeusRyhmaDto getKayttoOikeusRyhma(@PathVariable("id") Long id,
+                                                     @RequestParam(required = false) Boolean passiiviset) {
+        return kayttoOikeusService.findKayttoOikeusRyhma(id, passiiviset);
     }
 
 
@@ -151,7 +152,7 @@ public class KayttoOikeusRyhmaController {
             notes = "Päivittää käyttöoikeusryhmän tiedot annetun DTO:n avulla.")
     public KayttoOikeusRyhmaDto updateKayttoOikeusRyhma(@PathVariable("id") Long id, @RequestBody @Validated KayttoOikeusRyhmaModifyDto ryhmaData) {
         kayttoOikeusService.updateKayttoOikeusForKayttoOikeusRyhma(id, ryhmaData);
-        return kayttoOikeusService.findKayttoOikeusRyhma(id);
+        return kayttoOikeusService.findKayttoOikeusRyhma(id, true);
     }
 
     @RequestMapping(value = "/{id}/passivoi", method = RequestMethod.PUT)

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/controller/KutsuController.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/controller/KutsuController.java
@@ -1,11 +1,11 @@
 package fi.vm.sade.kayttooikeus.controller;
 
-import fi.vm.sade.kayttooikeus.dto.KutsuUpdateDto;
-import fi.vm.sade.kayttooikeus.repositories.dto.HenkiloCreateByKutsuDto;
 import fi.vm.sade.kayttooikeus.dto.KutsuCreateDto;
 import fi.vm.sade.kayttooikeus.dto.KutsuReadDto;
+import fi.vm.sade.kayttooikeus.dto.KutsuUpdateDto;
 import fi.vm.sade.kayttooikeus.enumeration.KutsuOrganisaatioOrder;
 import fi.vm.sade.kayttooikeus.repositories.criteria.KutsuCriteria;
+import fi.vm.sade.kayttooikeus.repositories.dto.HenkiloCreateByKutsuDto;
 import fi.vm.sade.kayttooikeus.service.IdentificationService;
 import fi.vm.sade.kayttooikeus.service.KutsuService;
 import fi.vm.sade.kayttooikeus.service.external.OppijanumerorekisteriClient;
@@ -108,7 +108,7 @@ public class KutsuController {
                                 @Validated @RequestBody HenkiloCreateByKutsuDto henkiloCreateByKutsuDto) {
         // This needs to be done like this since otherwice KO locks the table row for this henkilo and ONR can't update
         // it until the transaction finishes when ONR request timeouts.
-        HenkiloUpdateDto henkiloUpdateDto =  this.kutsuService.createHenkilo(temporaryToken, henkiloCreateByKutsuDto);
+        HenkiloUpdateDto henkiloUpdateDto = this.kutsuService.createHenkilo(temporaryToken, henkiloCreateByKutsuDto);
         this.oppijanumerorekisteriClient.updateHenkilo(henkiloUpdateDto);
         return this.identificationService.updateIdentificationAndGenerateTokenForHenkiloByOid(henkiloUpdateDto.getOidHenkilo());
     }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/KayttoOikeusRyhmaRepositoryCustom.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/KayttoOikeusRyhmaRepositoryCustom.java
@@ -14,7 +14,7 @@ public interface KayttoOikeusRyhmaRepositoryCustom {
 
     Boolean ryhmaNameFiExists(String ryhmaNameFi);
 
-    List<KayttoOikeusRyhmaDto> listAll();
+    List<KayttoOikeusRyhmaDto> listAll(boolean naytaPassivoidut);
 
     List<Tuple> findOrganisaatioOidAndRyhmaIdByHenkiloOid(String oid);
 

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/KayttoOikeusRyhmaRepositoryCustom.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/KayttoOikeusRyhmaRepositoryCustom.java
@@ -3,7 +3,6 @@ package fi.vm.sade.kayttooikeus.repositories;
 import com.querydsl.core.Tuple;
 import fi.vm.sade.kayttooikeus.dto.KayttoOikeusRyhmaDto;
 import fi.vm.sade.kayttooikeus.model.KayttoOikeusRyhma;
-import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,7 +10,7 @@ import java.util.Optional;
 public interface KayttoOikeusRyhmaRepositoryCustom {
     List<KayttoOikeusRyhmaDto> findByIdList(List<Long> idList);
 
-    Optional<KayttoOikeusRyhma> findByRyhmaId(Long id);
+    Optional<KayttoOikeusRyhma> findByRyhmaId(Long id, boolean naytaPassivoitu);
 
     Boolean ryhmaNameFiExists(String ryhmaNameFi);
 

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/impl/KayttoOikeusRyhmaRepositoryImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/impl/KayttoOikeusRyhmaRepositoryImpl.java
@@ -67,15 +67,17 @@ public class KayttoOikeusRyhmaRepositoryImpl implements KayttoOikeusRyhmaReposit
     }
 
     @Override
-    public Optional<KayttoOikeusRyhma> findByRyhmaId(Long id) {
+    public Optional<KayttoOikeusRyhma> findByRyhmaId(Long id, boolean naytaPassivoitu) {
         QKayttoOikeusRyhma kayttoOikeusRyhma = QKayttoOikeusRyhma.kayttoOikeusRyhma;
-        return Optional.ofNullable(jpa()
+        JPAQuery<KayttoOikeusRyhma> query = jpa()
                 .select(kayttoOikeusRyhma)
                 .from(kayttoOikeusRyhma)
-                .where(kayttoOikeusRyhma.passivoitu.eq(false)
-                        .and(kayttoOikeusRyhma.id.eq(id)))
-                .distinct()
-                .fetchFirst());
+                .where(kayttoOikeusRyhma.id.eq(id))
+                .distinct();
+        if (!naytaPassivoitu) {
+            query.where(kayttoOikeusRyhma.passivoitu.eq(false));
+        }
+        return Optional.ofNullable(query.fetchFirst());
     }
 
     @Override

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/impl/KayttoOikeusRyhmaRepositoryImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/impl/KayttoOikeusRyhmaRepositoryImpl.java
@@ -92,14 +92,16 @@ public class KayttoOikeusRyhmaRepositoryImpl implements KayttoOikeusRyhmaReposit
     }
 
     @Override
-    public List<KayttoOikeusRyhmaDto> listAll() {
+    public List<KayttoOikeusRyhmaDto> listAll(boolean naytaPassivoidut) {
         QKayttoOikeusRyhma kayttoOikeusRyhma = QKayttoOikeusRyhma.kayttoOikeusRyhma;
-        return jpa().from(kayttoOikeusRyhma)
+        JPAQuery<KayttoOikeusRyhmaDto> query = jpa().from(kayttoOikeusRyhma)
                 .leftJoin(kayttoOikeusRyhma.nimi)
-                .where(kayttoOikeusRyhma.passivoitu.eq(false))
                 .orderBy(kayttoOikeusRyhma.id.asc())
-                .select(KayttoOikeusRyhmaDtoBean())
-                .fetch();
+                .select(KayttoOikeusRyhmaDtoBean());
+        if (!naytaPassivoidut) {
+            query.where(kayttoOikeusRyhma.passivoitu.eq(false));
+        }
+        return query.fetch();
     }
 
     @Override

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/KayttoOikeusService.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/KayttoOikeusService.java
@@ -57,10 +57,19 @@ public interface KayttoOikeusService {
 
     void updateKayttoOikeusForKayttoOikeusRyhma(long id, KayttoOikeusRyhmaModifyDto ryhmaData);
 
+    /**
+     * Passivoi aktiivisen käyttöoikeusryhmän. Poistaa myönnetyt käyttöoikeudet tähän ryhmään.
+     * @param id Katiivisen käyttöoikeusryhmän ID
+     */
     void passivoiKayttooikeusryhma(long id);
 
     List<KayttoOikeusRyhmaDto> findKayttoOikeusRyhmasByKayttoOikeusList(Map<String, String> kayttoOikeusList);
 
     AuthorizationDataDto findAuthorizationDataByOid(String oid);
 
+    /**
+     * Aktivoi passiivisen käyttöoikeusryhmän
+     * @param id Passiivisen käyttöoikeusryhmän ID
+     */
+    void aktivoiKayttooikeusryhma(Long id);
 }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/KayttoOikeusService.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/KayttoOikeusService.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public interface KayttoOikeusService {
     KayttoOikeusDto findKayttoOikeusById(long kayttoOikeusId);
 
-    List<KayttoOikeusRyhmaDto> listAllKayttoOikeusRyhmas();
+    List<KayttoOikeusRyhmaDto> listAllKayttoOikeusRyhmas(Boolean passiiviset);
 
     List<PalveluKayttoOikeusDto> listKayttoOikeusByPalvelu(String palveluName);
 
@@ -43,7 +43,7 @@ public interface KayttoOikeusService {
      */
     List<MyonnettyKayttoOikeusDto> listMyonnettyKayttoOikeusRyhmasByHenkiloAndOrganisaatio(String oid, String organisaatioOid);
 
-    KayttoOikeusRyhmaDto findKayttoOikeusRyhma(long id);
+    KayttoOikeusRyhmaDto findKayttoOikeusRyhma(long id, Boolean passiiviset);
 
     List<KayttoOikeusRyhmaDto> findSubRyhmasByMasterRyhma(long id);
 

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttoOikeusServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttoOikeusServiceImpl.java
@@ -359,6 +359,14 @@ public class KayttoOikeusServiceImpl extends AbstractService implements KayttoOi
         return new AuthorizationDataDto(accessRights, groups);
     }
 
+    @Override
+    @Transactional
+    public void aktivoiKayttooikeusryhma(Long id) {
+        KayttoOikeusRyhma kayttoOikeusRyhma = kayttoOikeusRyhmaRepository.findById(id).orElseThrow(()
+                -> new NotFoundException("kayttooikeusryhma not found"));
+        kayttoOikeusRyhma.setPassivoitu(false);
+    }
+
     private void setKayttoOikeusRyhmas(KayttoOikeusRyhmaModifyDto ryhmaData, KayttoOikeusRyhma kayttoOikeusRyhma) {
         Set<KayttoOikeus> givenKOs = new HashSet<>();
         for (PalveluRooliModifyDto prDto : ryhmaData.getPalvelutRoolit()) {

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttoOikeusServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttoOikeusServiceImpl.java
@@ -197,8 +197,8 @@ public class KayttoOikeusServiceImpl extends AbstractService implements KayttoOi
     @Override
     @Transactional(readOnly = true)
     public KayttoOikeusRyhmaDto findKayttoOikeusRyhma(long id) {
-        KayttoOikeusRyhma kayttoOikeusRyhma = kayttoOikeusRyhmaRepository.findByRyhmaId(id).orElseThrow(()
-                -> new NotFoundException("kayttooikeusryhma not found"));
+        KayttoOikeusRyhma kayttoOikeusRyhma = kayttoOikeusRyhmaRepository.findByRyhmaId(id, this.permissionCheckerService.isCurrentUserAdmin())
+                .orElseThrow(() -> new NotFoundException("kayttooikeusryhma not found"));
         KayttoOikeusRyhmaDto ryhma = mapper.map(kayttoOikeusRyhma, KayttoOikeusRyhmaDto.class);
         return localizationService.localize(ryhma);
     }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttoOikeusServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttoOikeusServiceImpl.java
@@ -69,8 +69,9 @@ public class KayttoOikeusServiceImpl extends AbstractService implements KayttoOi
 
     @Override
     @Transactional(readOnly = true)
-    public List<KayttoOikeusRyhmaDto> listAllKayttoOikeusRyhmas() {
-        return localizationService.localize(findAllKayttoOikeusRyhmasAsDtos());
+    public List<KayttoOikeusRyhmaDto> listAllKayttoOikeusRyhmas(Boolean passiiviset) {
+        boolean naytaPassiiviset = Boolean.TRUE.equals(passiiviset) && this.permissionCheckerService.isCurrentUserAdmin();
+        return localizationService.localize(findAllKayttoOikeusRyhmasAsDtos(naytaPassiiviset));
     }
 
     @Override
@@ -123,7 +124,7 @@ public class KayttoOikeusServiceImpl extends AbstractService implements KayttoOi
     @Transactional(readOnly = true)
     public List<KayttoOikeusRyhmaDto> listPossibleRyhmasByOrganization(String organisaatioOid) {
         return localizationService.localize(getRyhmasWithoutOrganizationLimitations(
-                organisaatioOid, findAllKayttoOikeusRyhmasAsDtos()));
+                organisaatioOid, findAllKayttoOikeusRyhmasAsDtos(false)));
     }
 
     @Override
@@ -196,8 +197,9 @@ public class KayttoOikeusServiceImpl extends AbstractService implements KayttoOi
 
     @Override
     @Transactional(readOnly = true)
-    public KayttoOikeusRyhmaDto findKayttoOikeusRyhma(long id) {
-        KayttoOikeusRyhma kayttoOikeusRyhma = kayttoOikeusRyhmaRepository.findByRyhmaId(id, this.permissionCheckerService.isCurrentUserAdmin())
+    public KayttoOikeusRyhmaDto findKayttoOikeusRyhma(long id, Boolean passiiviset) {
+        boolean naytaPassiiviset = Boolean.TRUE.equals(passiiviset) && this.permissionCheckerService.isCurrentUserAdmin();
+        KayttoOikeusRyhma kayttoOikeusRyhma = kayttoOikeusRyhmaRepository.findByRyhmaId(id, naytaPassiiviset)
                 .orElseThrow(() -> new NotFoundException("kayttooikeusryhma not found"));
         KayttoOikeusRyhmaDto ryhma = mapper.map(kayttoOikeusRyhma, KayttoOikeusRyhmaDto.class);
         return localizationService.localize(ryhma);
@@ -428,8 +430,8 @@ public class KayttoOikeusServiceImpl extends AbstractService implements KayttoOi
         return new ArrayList<>(byIds.values());
     }
 
-    private List<KayttoOikeusRyhmaDto> findAllKayttoOikeusRyhmasAsDtos() {
-        return addOrganisaatioViitteesToRyhmas(kayttoOikeusRyhmaRepository.listAll());
+    private List<KayttoOikeusRyhmaDto> findAllKayttoOikeusRyhmasAsDtos(boolean naytaPassiiviset) {
+        return addOrganisaatioViitteesToRyhmas(kayttoOikeusRyhmaRepository.listAll(naytaPassiiviset));
     }
 
     private List<KayttoOikeusRyhmaDto> getGrantableRyhmasWithoutOrgLimitations(String organisaatioOid, String myontajaOid) {
@@ -439,7 +441,7 @@ public class KayttoOikeusServiceImpl extends AbstractService implements KayttoOi
 
 
         List<KayttoOikeusRyhmaDto> allRyhmas = (isEmpty(slaveIds) || this.permissionCheckerService.isCurrentUserAdmin()) ?
-                kayttoOikeusRyhmaRepository.listAll() : kayttoOikeusRyhmaRepository.findByIdList(slaveIds);
+                kayttoOikeusRyhmaRepository.listAll(false) : kayttoOikeusRyhmaRepository.findByIdList(slaveIds);
         return getRyhmasWithoutOrganizationLimitations(organisaatioOid,
                 addOrganisaatioViitteesToRyhmas(allRyhmas));
     }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttooikeusAnomusServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KayttooikeusAnomusServiceImpl.java
@@ -35,7 +35,6 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import static fi.vm.sade.kayttooikeus.service.impl.PermissionCheckerServiceImpl.PALVELU_KAYTTOOIKEUS;
 import static fi.vm.sade.kayttooikeus.util.FunctionalUtils.appending;
@@ -311,6 +310,9 @@ public class KayttooikeusAnomusServiceImpl extends AbstractService implements Ka
             if (!k.isSallittuKayttajatyypilla(anoja.getKayttajaTyyppi())) {
                 throw new IllegalStateException(String.format("Käyttöoikeusryhmää %d ei ole sallittu henkilön %s käyttäjätyypille %s", k.getId(), anoja.getOidHenkilo(), anoja.getKayttajaTyyppi()));
             }
+            if (k.isPassivoitu()) {
+                throw new IllegalArgumentException(String.format("Passivoituun käyttöoikeusryhmään %d ei voi anoa oikeuksia", k.getId()));
+            }
             HaettuKayttoOikeusRyhma h = new HaettuKayttoOikeusRyhma();
             h.setKayttoOikeusRyhma(k);
             anomus.addHaettuKayttoOikeusRyhma(h);
@@ -402,6 +404,9 @@ public class KayttooikeusAnomusServiceImpl extends AbstractService implements Ka
         Optional.of(myonnettavaKayttoOikeusRyhma)
                 .filter(kayttooikeusRyhma -> kayttooikeusRyhma.isSallittuKayttajatyypilla(anoja.getKayttajaTyyppi()))
                 .orElseThrow(() -> new IllegalStateException(String.format("Yritetään myöntää käyttöoikeutta väärälle käyttäjätyypille %s käyttöoikeusryhmään %d kun sallitaan vain %s", anoja.getKayttajaTyyppi(), myonnettavaKayttoOikeusRyhma.getId(), myonnettavaKayttoOikeusRyhma.getSallittuKayttajatyyppi())));
+        if (myonnettavaKayttoOikeusRyhma.isPassivoitu()) {
+            throw new IllegalStateException(String.format("Passivoituun käyttöoikeusryhmään %d ei voi myöntää oikeuksia", myonnettavaKayttoOikeusRyhma.getId()));
+        }
         OrganisaatioHenkilo myonnettavaOrganisaatioHenkilo = this.findOrCreateHaettuOrganisaatioHenkilo(
                 organisaatioOid, anoja, tehtavanimike);
 

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/validators/HaettuKayttooikeusryhmaValidator.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/validators/HaettuKayttooikeusryhmaValidator.java
@@ -1,29 +1,20 @@
 package fi.vm.sade.kayttooikeus.service.validators;
 
-import com.google.common.collect.Lists;
 import fi.vm.sade.kayttooikeus.model.AnomuksenTila;
 import fi.vm.sade.kayttooikeus.model.HaettuKayttoOikeusRyhma;
-import fi.vm.sade.kayttooikeus.service.PermissionCheckerService;
-import fi.vm.sade.kayttooikeus.service.exception.ForbiddenException;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
 @Component
 public class HaettuKayttooikeusryhmaValidator implements Validator {
-    private PermissionCheckerService permissionCheckerService;
 
-    @Autowired
-    public HaettuKayttooikeusryhmaValidator(PermissionCheckerService permissionCheckerService) {
-        this.permissionCheckerService = permissionCheckerService;
-    }
-
-    public boolean supports(Class clazz) {
+    public boolean supports(@NotNull Class clazz) {
         return HaettuKayttoOikeusRyhma.class.equals(clazz);
     }
 
-    public void validate(Object object, Errors errors) {
+    public void validate(@NotNull Object object, @NotNull Errors errors) {
         HaettuKayttoOikeusRyhma haettuKayttooikeusryhma = (HaettuKayttoOikeusRyhma) object;
 
         if (haettuKayttooikeusryhma.getAnomus().getAnomuksenTila() != AnomuksenTila.ANOTTU) {

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/controller/KayttoOikeusRyhmaControllerTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/controller/KayttoOikeusRyhmaControllerTest.java
@@ -17,9 +17,7 @@ import static fi.vm.sade.kayttooikeus.service.impl.PermissionCheckerServiceImpl.
 import static fi.vm.sade.kayttooikeus.service.impl.PermissionCheckerServiceImpl.ROLE_REKISTERINPITAJA;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -39,7 +37,7 @@ public class KayttoOikeusRyhmaControllerTest extends AbstractControllerTest {
     @Test
     @WithMockUser(username = "1.2.3.4.5", authorities = "ROLE_APP_KAYTTOOIKEUS_READ")
     public void listKayttoOikeusRyhmaTest() throws Exception {
-        given(this.kayttoOikeusService.listAllKayttoOikeusRyhmas())
+        given(this.kayttoOikeusService.listAllKayttoOikeusRyhmas(isNull()))
             .willReturn(singletonList(KayttoOikeusRyhmaDto.builder()
                     .organisaatioViite(singletonList(OrganisaatioViiteDto.builder()
                             .organisaatioTyyppi("organisaatiotyyppi")
@@ -161,7 +159,7 @@ public class KayttoOikeusRyhmaControllerTest extends AbstractControllerTest {
     @Test
     @WithMockUser(username = "1.2.3.4.5", authorities = "ROLE_APP_KAYTTOOIKEUS_KAYTTOOIKEUSRYHMIEN_LUKU")
     public void getKayttoOikeusRyhmaTest() throws Exception {
-        given(this.kayttoOikeusService.findKayttoOikeusRyhma(44L))
+        given(this.kayttoOikeusService.findKayttoOikeusRyhma(eq(44L), isNull()))
                 .willReturn(buildKayttoOikeusRyhma());
 
         this.mvc.perform(get("/kayttooikeusryhma/44").accept(MediaType.APPLICATION_JSON_UTF8))
@@ -312,7 +310,7 @@ public class KayttoOikeusRyhmaControllerTest extends AbstractControllerTest {
     @Test
     @WithMockUser(username = "1.2.3.4.5", authorities = PALVELU_KAYTTOOIKEUS_PREFIX + ROLE_REKISTERINPITAJA)
     public void updateKayttoOikeusRyhmaTest() throws Exception {
-        given(kayttoOikeusService.findKayttoOikeusRyhma(eq(345L)))
+        given(kayttoOikeusService.findKayttoOikeusRyhma(eq(345L), eq(true)))
                 .willReturn(KayttoOikeusRyhmaDto.builder()
                         .id(345L)
                         .tunniste("kayttooikeusryhmä")

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/repositories/KayttoOikeusRyhmaRepositoryTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/repositories/KayttoOikeusRyhmaRepositoryTest.java
@@ -113,7 +113,7 @@ public class KayttoOikeusRyhmaRepositoryTest extends AbstractRepositoryTest {
 
     @Test
     public void findByIdTest(){
-        Long id =populate(kayttoOikeusRyhma("RYHMÄ")
+        Long id = populate(kayttoOikeusRyhma("RYHMÄ")
                 .withNimi(text("FI", "Kuvaus"))
                 .withViite(viite(kayttoOikeusRyhma("RYHMA1"), "TYYPPI"))
                 .withOikeus(oikeus("APP1", "READ"))
@@ -124,7 +124,7 @@ public class KayttoOikeusRyhmaRepositoryTest extends AbstractRepositoryTest {
                 .withOikeus(oikeus("APP1", "READ"))
                 .withOikeus(oikeus("APP2", "WRITE"))).getId();
 
-        Optional<KayttoOikeusRyhma> ryhma = kayttoOikeusRyhmaRepository.findByRyhmaId(id);
+        Optional<KayttoOikeusRyhma> ryhma = kayttoOikeusRyhmaRepository.findByRyhmaId(id, false);
         assertTrue(ryhma.isPresent());
         KayttoOikeusRyhma koRyhma = ryhma.get();
         assertEquals("RYHMÄ", koRyhma.getTunniste());
@@ -133,13 +133,13 @@ public class KayttoOikeusRyhmaRepositoryTest extends AbstractRepositoryTest {
         assertEquals("Kuvaus", koRyhma.getNimi().getTexts().stream().filter(text -> text.getLang().equals("FI")).findFirst().get().getText());
         assertEquals(2, koRyhma.getKayttoOikeus().size());
 
-        Optional<KayttoOikeusRyhma> hiddenRyhma  = kayttoOikeusRyhmaRepository.findById(hiddenRyhmaId);
+        Optional<KayttoOikeusRyhma> hiddenRyhma = kayttoOikeusRyhmaRepository.findById(hiddenRyhmaId);
         assertTrue(hiddenRyhma.isPresent());
 
-        hiddenRyhma = kayttoOikeusRyhmaRepository.findByRyhmaId(hiddenRyhmaId);
+        hiddenRyhma = kayttoOikeusRyhmaRepository.findByRyhmaId(hiddenRyhmaId, false);
         assertFalse(hiddenRyhma.isPresent());
 
-        Optional<KayttoOikeusRyhma> nonexistent = kayttoOikeusRyhmaRepository.findByRyhmaId(434323423L);
+        Optional<KayttoOikeusRyhma> nonexistent = kayttoOikeusRyhmaRepository.findByRyhmaId(434323423L, false);
         assertFalse(nonexistent.isPresent());
     }
 
@@ -182,7 +182,7 @@ public class KayttoOikeusRyhmaRepositoryTest extends AbstractRepositoryTest {
         ryhmas = kayttoOikeusRyhmaRepository.listAll();
         assertEquals(1, ryhmas.size());
 
-        KayttoOikeusRyhma ryhma = kayttoOikeusRyhmaRepository.findByRyhmaId(kor.getId()).get();
+        KayttoOikeusRyhma ryhma = kayttoOikeusRyhmaRepository.findByRyhmaId(kor.getId(), false).get();
         assertEquals("TEST", ryhma.getTunniste());
         assertEquals("roolirajoite", ryhma.getRooliRajoite());
         assertEquals("kuvaus", ryhma.getNimi().getTexts().stream().findFirst().get().getText());

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/repositories/KayttoOikeusRyhmaRepositoryTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/repositories/KayttoOikeusRyhmaRepositoryTest.java
@@ -47,7 +47,7 @@ public class KayttoOikeusRyhmaRepositoryTest extends AbstractRepositoryTest {
                 .withOikeus(oikeus("APP1", "READ"))
                 .withOikeus(oikeus("APP2", "WRITE")));
 
-        List<KayttoOikeusRyhmaDto> ryhmas = kayttoOikeusRyhmaRepository.listAll();
+        List<KayttoOikeusRyhmaDto> ryhmas = kayttoOikeusRyhmaRepository.listAll(false);
         assertEquals(2, ryhmas.size());
         assertEquals("RYHMÄ", ryhmas.get(0).getName());
     }
@@ -166,7 +166,7 @@ public class KayttoOikeusRyhmaRepositoryTest extends AbstractRepositoryTest {
     public void insertTest(){
 
         KayttoOikeus oikeus = populate(oikeus("APP1", "READ"));
-        List<KayttoOikeusRyhmaDto> ryhmas = kayttoOikeusRyhmaRepository.listAll();
+        List<KayttoOikeusRyhmaDto> ryhmas = kayttoOikeusRyhmaRepository.listAll(false);
         assertEquals(0, ryhmas.size());
 
         KayttoOikeusRyhma kor = new KayttoOikeusRyhma();
@@ -179,7 +179,7 @@ public class KayttoOikeusRyhmaRepositoryTest extends AbstractRepositoryTest {
         kor.setRooliRajoite("roolirajoite");
         kor = kayttoOikeusRyhmaRepository.save(kor);
 
-        ryhmas = kayttoOikeusRyhmaRepository.listAll();
+        ryhmas = kayttoOikeusRyhmaRepository.listAll(false);
         assertEquals(1, ryhmas.size());
 
         KayttoOikeusRyhma ryhma = kayttoOikeusRyhmaRepository.findByRyhmaId(kor.getId(), false).get();

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/KayttooikeusAnomusServiceTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/KayttooikeusAnomusServiceTest.java
@@ -48,12 +48,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.util.Maps.newHashMap;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anySet;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -378,6 +373,38 @@ public class KayttooikeusAnomusServiceTest {
         assertThat(kayttoOikeusRyhmaTapahtumaHistoria.getSyy()).isEqualTo("Oikeuksien lisäys");
 
     }
+
+    @Test
+    @WithMockUser("1.2.3.4.1")
+    public void kayttooikeudenMyontaminenEpaonnistuuPassivoituunKayttooikeusryhmaan() {
+        given(this.permissionCheckerService.notOwnData(anyString())).willReturn(true);
+        given(this.permissionCheckerService.checkRoleForOrganisation(any(), anyMap())).willReturn(true);
+        KayttoOikeusRyhma kayttoOikeusRyhma = createKayttoOikeusRyhmaWithViite(2001L);
+        kayttoOikeusRyhma.setPassivoitu(true);
+        given(this.kayttooikeusryhmaDataRepository.findById(2001L)).willReturn(Optional.of(kayttoOikeusRyhma));
+        given(this.henkiloDataRepository.findByOidHenkilo("1.2.3.4.5")).willReturn(Optional.of(createHenkilo("1.2.3.4.5")));
+        given(this.henkiloDataRepository.findByOidHenkilo("1.2.3.4.1"))
+                .willReturn(Optional.of(createHenkiloWithOrganisaatio("1.2.3.4.5", "1.2.0.0.1", false)));
+        given(this.permissionCheckerService.getCurrentUserOid()).willReturn("1.2.3.4.1");
+        given(this.permissionCheckerService.organisaatioLimitationCheck(eq("1.2.0.0.1"), anySet())).willReturn(true);
+        given(this.organisaatioHenkiloRepository.findByHenkiloOidHenkilo("1.2.3.4.1"))
+                .willReturn(Lists.newArrayList(OrganisaatioHenkilo.builder().organisaatioOid("1.2.0.0.1").build()));
+        given(this.permissionCheckerService.organisaatioViiteLimitationsAreValid(2001L)).willReturn(true);
+        given(this.permissionCheckerService.kayttooikeusMyontoviiteLimitationCheck(2001L)).willReturn(true);
+        given(this.myonnettyKayttoOikeusRyhmaTapahtumaRepository.findMyonnettyTapahtuma(2001L,
+                "1.2.0.0.1", "1.2.3.4.5"))
+                .willReturn(Optional.empty());
+        OrganisaatioPerustieto organisaatio = OrganisaatioPerustieto.builder().status(OrganisaatioStatus.AKTIIVINEN).build();
+        given(this.organisaatioClient.getOrganisaatioPerustiedotCached(any())).willReturn(Optional.of(organisaatio));
+
+        GrantKayttooikeusryhmaDto grantKayttooikeusryhmaDto = createGrantKayttooikeusryhmaDto(2001L,
+                LocalDate.now().plusYears(1));
+        assertThatThrownBy(() -> this.kayttooikeusAnomusService.grantKayttooikeusryhma("1.2.3.4.5", "1.2.0.0.1", Lists.newArrayList(grantKayttooikeusryhmaDto)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Passivoituun käyttöoikeusryhmään ")
+                .hasMessageContaining(" ei voi myöntää oikeuksia");
+    }
+
     @Test
     @WithMockUser("1.2.3.4.1")
     public void kayttooikeudenMyontaminenEpaonnistuuVaaralleKayttajatyypille() {
@@ -624,6 +651,35 @@ public class KayttooikeusAnomusServiceTest {
         HaettuKayttoOikeusRyhma haettuKayttoOikeusRyhma = createHaettuKayttoOikeusRyhma("1.2.3.4.5", "1.2.3.4.1",
                 "1.2.0.0.1", "devaaja", "Haluan devata", 2001L);
         haettuKayttoOikeusRyhma.getKayttoOikeusRyhma().setSallittuKayttajatyyppi(KayttajaTyyppi.PALVELU);
+        given(this.haettuKayttooikeusRyhmaRepository.findById(1L))
+                .willReturn(Optional.of(haettuKayttoOikeusRyhma));
+        given(this.kayttooikeusryhmaDataRepository.findById(2001L)).willReturn(Optional.of(haettuKayttoOikeusRyhma.getKayttoOikeusRyhma()));
+        given(this.permissionCheckerService.checkRoleForOrganisation(anyList(), anyMap()))
+                .willReturn(true);
+        given(this.permissionCheckerService.getCurrentUserOid()).willReturn("1.2.3.4.1");
+        given(this.permissionCheckerService.organisaatioLimitationCheck(eq("1.2.0.0.1"), anySet())).willReturn(true);
+        given(this.organisaatioHenkiloRepository.findByHenkiloOidHenkilo("1.2.3.4.1"))
+                .willReturn(Lists.newArrayList(OrganisaatioHenkilo.builder().organisaatioOid("1.2.0.0.1").build()));
+        given(this.permissionCheckerService.organisaatioViiteLimitationsAreValid(2001L)).willReturn(true);
+        given(this.permissionCheckerService.kayttooikeusMyontoviiteLimitationCheck(2001L)).willReturn(true);
+        given(this.permissionCheckerService.notOwnData("1.2.3.4.5")).willReturn(true);
+        given(this.henkiloDataRepository.findByOidHenkilo("1.2.3.4.5")).willReturn(Optional.of(createHenkilo("1.2.3.4.5")));
+        given(this.henkiloDataRepository.findByOidHenkilo("1.2.3.4.1")).willReturn(Optional.of(createHenkilo("1.2.3.4.1")));
+
+        UpdateHaettuKayttooikeusryhmaDto updateHaettuKayttooikeusryhmaDto = createUpdateHaettuKayttooikeusryhmaDto(1L,
+                "HYLATTY", LocalDate.now().plusYears(1));
+        this.kayttooikeusAnomusService.updateHaettuKayttooikeusryhma(updateHaettuKayttooikeusryhmaDto);
+
+        assertThat(haettuKayttoOikeusRyhma.getAnomus().getAnomuksenTila()).isEqualByComparingTo(AnomuksenTila.HYLATTY);
+        assertThat(haettuKayttoOikeusRyhma.getAnomus().getAnomusTyyppi()).isEqualByComparingTo(AnomusTyyppi.UUSI);
+    }
+
+    @Test
+    @WithMockUser("1.2.3.4.1")
+    public void passivoidunKayttoikeusRyhmanHylkaaminenOnnistuu() {
+        HaettuKayttoOikeusRyhma haettuKayttoOikeusRyhma = createHaettuKayttoOikeusRyhma("1.2.3.4.5", "1.2.3.4.1",
+                "1.2.0.0.1", "devaaja", "Haluan devata", 2001L);
+        haettuKayttoOikeusRyhma.getKayttoOikeusRyhma().setPassivoitu(true);
         given(this.haettuKayttooikeusRyhmaRepository.findById(1L))
                 .willReturn(Optional.of(haettuKayttoOikeusRyhma));
         given(this.kayttooikeusryhmaDataRepository.findById(2001L)).willReturn(Optional.of(haettuKayttoOikeusRyhma.getKayttoOikeusRyhma()));

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/it/KayttoOikeusServiceTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/it/KayttoOikeusServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.LocalDate;
 import java.time.Period;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -364,6 +365,25 @@ public class KayttoOikeusServiceTest extends AbstractServiceIntegrationTest {
         assertTrue(createdRyhma.getKuvaus().get("FI").contentEquals("uusi kuvaus"));
         assertTrue(createdRyhma.getOrganisaatioViite().get(0).getOrganisaatioTyyppi().contentEquals("uusi org tyyppi"));
         assertNull(createdRyhma.getSallittuKayttajatyyppi());
+    }
+
+    @Test
+    @WithMockUser(username = "1.2.3.4.5")
+    public void updatePassivoitu() {
+        KayttoOikeusRyhma passivoituKayttoOikeusRyhma = populate(kayttoOikeusRyhma("RYHMA")
+                .withNimi(text("FI", "Käyttäjähallinta")
+                        .put("EN", "User management"))
+                .withOikeus(oikeus("HENKILOHALLINTA", "CRUD"))
+                .withOikeus(oikeus("KOODISTO", "READ"))
+                .asPassivoitu());
+        KayttoOikeusRyhmaModifyDto ryhmaModifyDto = KayttoOikeusRyhmaModifyDto.builder()
+                .nimi(new TextGroupDto()
+                        .put("FI", "Uusi nimi")
+                        .put("SV", "Uusi nimi sv")
+                        .put("EN", "Uusi nimi en"))
+                .palvelutRoolit(new ArrayList<>())
+                .build();
+        this.kayttoOikeusService.updateKayttoOikeusForKayttoOikeusRyhma(passivoituKayttoOikeusRyhma.getId(), ryhmaModifyDto);
     }
 
     @Test

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/it/KayttoOikeusServiceTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/it/KayttoOikeusServiceTest.java
@@ -66,7 +66,7 @@ public class KayttoOikeusServiceTest extends AbstractServiceIntegrationTest {
                 .withViite(viite(kayttoOikeusRyhma("RYHMA1"), "TYYPPI"))
                 .withOikeus(oikeus("KOODISTO", "CRUD")));
         
-        List<KayttoOikeusRyhmaDto> ryhmas = kayttoOikeusService.listAllKayttoOikeusRyhmas();
+        List<KayttoOikeusRyhmaDto> ryhmas = kayttoOikeusService.listAllKayttoOikeusRyhmas(false);
         assertEquals(2, ryhmas.size());
 
     }
@@ -209,7 +209,7 @@ public class KayttoOikeusServiceTest extends AbstractServiceIntegrationTest {
                 .containsExactlyInAnyOrder("RYHMA-ORGANISAATIORYHMILLE1", "RYHMA-ORGANISAATIORYHMILLE2");
 
         ryhmat = kayttoOikeusService.listPossibleRyhmasByOrganization("1.2.246.562.10.00000000001");
-        assertThat(ryhmat).hasSize(kayttoOikeusService.listAllKayttoOikeusRyhmas().size());
+        assertThat(ryhmat).hasSize(kayttoOikeusService.listAllKayttoOikeusRyhmas(false).size());
     }
 
     private static OrganisaatioPerustieto oppilaitos(String oid, String oppilaitostyyppi) {
@@ -232,7 +232,7 @@ public class KayttoOikeusServiceTest extends AbstractServiceIntegrationTest {
                 .withOikeus(oikeus("KOODISTO", "CRUD"))
                 .withSallittu(KayttajaTyyppi.PALVELU)).getId();
 
-        KayttoOikeusRyhmaDto ryhma = kayttoOikeusService.findKayttoOikeusRyhma(id);
+        KayttoOikeusRyhmaDto ryhma = kayttoOikeusService.findKayttoOikeusRyhma(id, false);
         assertNotNull(ryhma);
         assertEquals("RYHMA2", ryhma.getName());
         assertEquals(KayttajaTyyppi.PALVELU, ryhma.getSallittuKayttajatyyppi());
@@ -341,7 +341,7 @@ public class KayttoOikeusServiceTest extends AbstractServiceIntegrationTest {
                 .build();
 
         long createdRyhmaId = kayttoOikeusService.createKayttoOikeusRyhma(ryhma);
-        KayttoOikeusRyhmaDto createdRyhma = kayttoOikeusService.findKayttoOikeusRyhma(createdRyhmaId);
+        KayttoOikeusRyhmaDto createdRyhma = kayttoOikeusService.findKayttoOikeusRyhma(createdRyhmaId, false);
 
         assertNotNull(createdRyhma);
         assertTrue(createdRyhma.getName().startsWith("ryhmäname_"));
@@ -359,7 +359,7 @@ public class KayttoOikeusServiceTest extends AbstractServiceIntegrationTest {
         ryhma.setSallittuKayttajatyyppi(null);
         kayttoOikeusService.updateKayttoOikeusForKayttoOikeusRyhma(createdRyhmaId, ryhma);
 
-        createdRyhma = kayttoOikeusService.findKayttoOikeusRyhma(createdRyhmaId);
+        createdRyhma = kayttoOikeusService.findKayttoOikeusRyhma(createdRyhmaId, false);
         assertTrue(createdRyhma.getDescription().get("FI").contentEquals("uusi nimi"));
         assertTrue(createdRyhma.getKuvaus().get("FI").contentEquals("uusi kuvaus"));
         assertTrue(createdRyhma.getOrganisaatioViite().get(0).getOrganisaatioTyyppi().contentEquals("uusi org tyyppi"));

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/it/KutsuServiceTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/it/KutsuServiceTest.java
@@ -51,12 +51,12 @@ import static fi.vm.sade.kayttooikeus.repositories.populate.KutsuOrganisaatioPop
 import static fi.vm.sade.kayttooikeus.repositories.populate.OrganisaatioHenkiloKayttoOikeusPopulator.myonnettyKayttoOikeus;
 import static fi.vm.sade.kayttooikeus.repositories.populate.OrganisaatioHenkiloPopulator.organisaatioHenkilo;
 import static fi.vm.sade.kayttooikeus.repositories.populate.TextGroupPopulator.text;
-import static fi.vm.sade.kayttooikeus.service.impl.PermissionCheckerServiceImpl.*;
+import static fi.vm.sade.kayttooikeus.service.impl.PermissionCheckerServiceImpl.PALVELU_KAYTTOOIKEUS;
+import static fi.vm.sade.kayttooikeus.service.impl.PermissionCheckerServiceImpl.ROLE_CRUD;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -581,7 +581,7 @@ public class KutsuServiceTest extends AbstractServiceIntegrationTest {
     }
 
     @Test
-    public void kutsunVainPalvelulleSallittuKayttooikeusRyhmaOhitetaan() {
+    public void vainPalvelulleSallittuJaPassivoituKayttooikeusRyhmaOhitetaan() {
         given(this.oppijanumerorekisteriClient.getHenkilonPerustiedot(eq("1.2.3.4.1")))
                 .willReturn(Optional.of(HenkiloPerustietoDto.builder().hetu("valid hetu").build()));
         populate(KutsuPopulator.kutsu("arpa", "kuutio", "arpa@kuutio.fi")
@@ -592,6 +592,9 @@ public class KutsuServiceTest extends AbstractServiceIntegrationTest {
                         .ryhma(KayttoOikeusRyhmaPopulator.kayttoOikeusRyhma("ryhma")
                                 .withNimi(text("FI", "Kuvaus"))
                                 .withSallittu(KayttajaTyyppi.PALVELU))
+                        .ryhma(KayttoOikeusRyhmaPopulator.kayttoOikeusRyhma("passivoituryhma")
+                                .withNimi(text("FI", "Kuvaus"))
+                                .asPassivoitu())
                 ));
         populate(HenkiloPopulator.henkilo("1.2.3.4.5"));
         populate(HenkiloPopulator.henkilo("1.2.3.4.1"));


### PR DESCRIPTION
- Antaa rekisterinpitäjän aktivoida passivoitu käyttöoikeusryhmä
- Antaa rekisterinpitäjän hakea ja muokata passivoitu käyttöoikeusryhmä
- Antaa rekisterinpitäjän listata passivoidut käyttöoikeusryhmät
- Ei salli passivoitua käyttöoikeusryhmää kutsua tai anomusta luodessa ja suoraan käyttöoikeutta myönnettäessä
- Ohittaa kutsun kautta passivoituun käyttöoikeusryhmään myönnettävät oikeudet
- Sallii kuitenkin anomuksen hylkäämisen passivoituun käyttöoikeusryhmään