### PR TITLE
SEC-68 : Remove old permission check fallback

### DIFF
--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/PermissionCheckerServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/PermissionCheckerServiceImpl.java
@@ -157,19 +157,6 @@ public class PermissionCheckerServiceImpl implements PermissionCheckerService {
 
         PermissionCheckResponseDto response = externalPermissionClient.getPermission(permissionCheckService,  permissionCheckRequestDto);
 
-//        SURElla ei kaikissa tapauksissa (esim. jos YO tutkinto ennen 90-lukua) ole tietoa
-//        henkilösta, joten pitää kysyä varmuuden vuoksi myös haku-appilta ja sen jälkeen atarulta
-        if (!response.isAccessAllowed() && ExternalPermissionService.SURE.equals(permissionCheckService)) {
-            PermissionCheckResponseDto responseHakuApp = externalPermissionClient.getPermission(
-                    ExternalPermissionService.HAKU_APP, permissionCheckRequestDto);
-            if (!responseHakuApp.isAccessAllowed()) {
-                return externalPermissionClient.getPermission(ExternalPermissionService.ATARU,permissionCheckRequestDto).isAccessAllowed();
-            } else {
-                return true;
-            }
-            
-        }
-
         if (!response.isAccessAllowed()) {
             LOG.error("Insufficient roles. permission check done from external service: {} " +
                     "Logged in user: {} " +


### PR DESCRIPTION
Suoritusrekisteri is supposed to be able to take care of
it's own hakemus based permission checks now that
SEC-68 is deployed (on 11th of April 2019), so we can
remove them checks in from here.