### PR TITLE
Lisää Kosken käyttöoikeus LUKU_ESIOPETUS

### DIFF
--- a/kayttooikeus-service/src/main/resources/db/migration/V20190507165330000__koski_vain_esiopetus_kayttooikeus.sql
+++ b/kayttooikeus-service/src/main/resources/db/migration/V20190507165330000__koski_vain_esiopetus_kayttooikeus.sql
@@ -1,0 +1,1 @@
+select insertkayttooikeus('KOSKI', 'LUKU_ESIOPETUS', 'Rajaa organisaation Koski-lukuoikeus vain esiopetukseen');


### PR DESCRIPTION
Rajaa organisaation Koski-lukuoikeuden vain esiopetuksen
opiskeluoikeuksiin.