### PR TITLE
TOR-1170 Lisää Koski VST käyttöoikeudet

### DIFF
--- a/kayttooikeus-service/src/main/resources/db/migration/V20201216115706000__koski_vapaan_sivistystyon_oikeudet.sql
+++ b/kayttooikeus-service/src/main/resources/db/migration/V20201216115706000__koski_vapaan_sivistystyon_oikeudet.sql
@@ -1,0 +1,1 @@
+select insertkayttooikeus('KOSKI', 'VAPAANSIVISTYSTYONKOULUTUS', 'Saa nähdä vapaan sivistystyön opiskeluoikeuksia');


### PR DESCRIPTION
Vapaan sivistystyön opintoja ei ole aiemmin ollut Koski-palvelussa tallennettuna, jatkossa tulee olemaan. Niitä järjestävien organisaatioiden käyttäjiä varten tarvitaan erillinen opiskeluoikeustyyppikohtainen käyttöoikeus.