### PR TITLE
KJHH-1934: Refactor: Move shibboleth header decoding to controller

### DIFF
--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/VahvaTunnistusServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/VahvaTunnistusServiceImpl.java
@@ -76,12 +76,6 @@ public class VahvaTunnistusServiceImpl implements VahvaTunnistusService {
 
     @Override
     public String kasitteleKutsunTunnistus(String kutsuToken, String kielisyys, String hetu, String etunimet, String sukunimi) {
-        // Dekoodataan etunimet ja sukunimi manuaalisesti, koska shibboleth välittää ASCII-enkoodatut request headerit UTF-8 -merkistössä
-        Charset windows1252 = Charset.forName("Windows-1252");
-        Charset utf8 = Charset.forName("UTF-8");
-        etunimet = new String(etunimet.getBytes(windows1252), utf8);
-        sukunimi = new String(sukunimi.getBytes(windows1252), utf8);
-
         return identificationService.updateKutsuAndGenerateTemporaryKutsuToken(kutsuToken, hetu, etunimet, sukunimi)
                 .map(temporaryKutsuToken -> ophProperties.url("henkilo-ui.rekisteroidy", singletonMap("temporaryKutsuToken", temporaryKutsuToken)))
                 .orElseGet(() -> ophProperties.url("henkilo-ui.vahvatunnistus.virhe", kielisyys, "vanhakutsu"));

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/controller/CasControllerUnitTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/controller/CasControllerUnitTest.java
@@ -1,0 +1,44 @@
+package fi.vm.sade.kayttooikeus.controller;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class CasControllerUnitTest {
+
+    @InjectMocks
+    private CasController controller;
+
+    @Parameterized.Parameters(name = "shibbolethDecodeHeader: {0} -> {1}")
+    public static Collection<Object[]> parameters() throws IOException {
+        return asList(new Object[][] {
+                {"Tero Testi", "Tero Testi"},
+                {"Ã\u0084yrÃ¤mÃ¶", "Äyrämö"},
+        });
+    }
+
+    @Parameterized.Parameter(0)
+    public String encoded;
+    @Parameterized.Parameter(1)
+    public String decoded;
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void test() {
+        assertThat(controller.decodeShibbolethHeader(encoded)).isEqualTo(decoded);
+    }
+}


### PR DESCRIPTION
* Shibboleth uses UTF-8 encoding for propagating HTTP headers
* Tomcat defaults to ISO-8859-1 for decoding HTTP headers
* First and last names are read from HTTP headers
* Names typically contain charaters (e.g. umlauts) which will break
  due to the encoding mismatch
* -> Need to manually decode HTTP headers which may contain
  "sensitive" charaters