### PR TITLE
Kludge etunimien hakemiseen attribuuteista.

### DIFF
--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/security/casoppija/SuomiFiAuthenticationProcessingFilter.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/security/casoppija/SuomiFiAuthenticationProcessingFilter.java
@@ -16,7 +16,8 @@ public class SuomiFiAuthenticationProcessingFilter extends AbstractPreAuthentica
 
     public static final String HETU_ATTRIBUTE = "nationalIdentificationNumber";
     public static final String SUKUNIMI_ATTRIBUTE = "sn";
-    public static final String ETUNIMET_ATTRIBUTE = "firstName";
+    public static final String ETUNIMET_ATTRIBUTE = "FirstName";
+    public static final String ETUNIMET_ALT_ATTRIBUTE = "firstName";
     static final String OPPIJA_TICKET_PARAM_NAME = "ticket";
     static final String SUOMI_FI_DETAILS_ATTR_KEY = "suomiFiDetails";
 
@@ -66,7 +67,9 @@ public class SuomiFiAuthenticationProcessingFilter extends AbstractPreAuthentica
         Map<String, Object> attributes = assertion.getPrincipal().getAttributes();
         String hetu = (String) attributes.get(HETU_ATTRIBUTE);
         String sukunimi = (String) attributes.get(SUKUNIMI_ATTRIBUTE);
-        String etunimet = (String) attributes.get(ETUNIMET_ATTRIBUTE);
+        // epäselvää, millä attribuutilla etunimet ovat - esimerkeissä ristiriitaista tietoa!
+        String etunimet = (String) attributes.getOrDefault(
+                ETUNIMET_ATTRIBUTE, attributes.get(ETUNIMET_ALT_ATTRIBUTE));
         return new SuomiFiUserDetails(hetu, sukunimi, etunimet);
     }
 

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/config/security/casoppija/SuomiFiAuthenticationProcessingFilterTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/config/security/casoppija/SuomiFiAuthenticationProcessingFilterTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static fi.vm.sade.kayttooikeus.config.security.casoppija.SuomiFiAuthenticationProcessingFilter.ETUNIMET_ALT_ATTRIBUTE;
 import static fi.vm.sade.kayttooikeus.config.security.casoppija.SuomiFiAuthenticationProcessingFilter.ETUNIMET_ATTRIBUTE;
 import static fi.vm.sade.kayttooikeus.config.security.casoppija.SuomiFiAuthenticationProcessingFilter.HETU_ATTRIBUTE;
 import static fi.vm.sade.kayttooikeus.config.security.casoppija.SuomiFiAuthenticationProcessingFilter.SUKUNIMI_ATTRIBUTE;
@@ -82,6 +83,20 @@ public class SuomiFiAuthenticationProcessingFilterTest {
         SuomiFiUserDetails details = filter.extractUserDetails(assertion);
         assertEquals("123456-7890", details.hetu);
         assertEquals("Testi", details.sukunimi);
+        assertEquals("Testi-Petteri Einari", details.etunimet);
+    }
+
+    @Test
+    public void extractUserDetails_palauttaaEtunimetVaihtoehtoisellaAvaimella() {
+        Assertion assertion = mock(Assertion.class);
+        AttributePrincipal principal = mock(AttributePrincipal.class);
+        Map<String, Object> attributes = Map.of(
+                ETUNIMET_ALT_ATTRIBUTE, "Testi-Petteri Einari"
+        );
+        when(assertion.isValid()).thenReturn(true);
+        when(assertion.getPrincipal()).thenReturn(principal);
+        when(principal.getAttributes()).thenReturn(attributes);
+        SuomiFiUserDetails details = filter.extractUserDetails(assertion);
         assertEquals("Testi-Petteri Einari", details.etunimet);
     }
 


### PR DESCRIPTION
Joidenkin esimerkkien mukaan löytyy avaimella "firstName",
joidenkin "FirstName". Jälkimmäinen todennäköisemmin oikea,
joten korjattu käyttämään sitä; takaporttina mikäli ei löydy,
etsitään toisella.