### PR TITLE
KJHH-2095: Add scheduled task for purging obsoleted identifications

### DIFF
--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/properties/KayttooikeusProperties.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/properties/KayttooikeusProperties.java
@@ -35,6 +35,8 @@ public class KayttooikeusProperties {
             private Integer discardExpiredApplicationsMinute = 45;
             private Integer expirationThreshold = 2;
             private Long henkiloNimiCache = 100000L;
+            private Integer identificationCleanupHour = 1;
+            private Integer identificationCleanupMinute = 15;
         }
 
     }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/scheduling/IdentificationCleanupTask.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/scheduling/IdentificationCleanupTask.java
@@ -29,7 +29,8 @@ public class IdentificationCleanupTask extends RecurringTask {
 
     @Override
     public void execute(TaskInstance<Void> taskInstance, ExecutionContext executionContext) {
-        log.info("Purging mismatching identifications");
-        kayttajatiedotRepository.cleanObsoletedIdentifications();
+        log.info("Start identification cleanup process");
+        int rows = kayttajatiedotRepository.cleanObsoletedIdentifications();
+        log.info("Removed {} mismatching rows", rows);
     }
 }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/scheduling/IdentificationCleanupTask.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/scheduling/IdentificationCleanupTask.java
@@ -1,0 +1,35 @@
+package fi.vm.sade.kayttooikeus.config.scheduling;
+
+import com.github.kagkarlsson.scheduler.task.Daily;
+import com.github.kagkarlsson.scheduler.task.ExecutionContext;
+import com.github.kagkarlsson.scheduler.task.RecurringTask;
+import com.github.kagkarlsson.scheduler.task.TaskInstance;
+import fi.vm.sade.kayttooikeus.config.properties.KayttooikeusProperties;
+import fi.vm.sade.kayttooikeus.repositories.KayttajatiedotRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalTime;
+
+@Slf4j
+@Component
+public class IdentificationCleanupTask extends RecurringTask {
+
+    KayttajatiedotRepository kayttajatiedotRepository;
+
+    @Autowired
+    public IdentificationCleanupTask(KayttooikeusProperties kayttooikeusProperties, KayttajatiedotRepository kayttajatiedotRepository) {
+        super(IdentificationCleanupTask.class.getSimpleName(),
+                new Daily(LocalTime.of(
+                        kayttooikeusProperties.getScheduling().getConfiguration().getIdentificationCleanupHour(),
+                        kayttooikeusProperties.getScheduling().getConfiguration().getIdentificationCleanupMinute())));
+        this.kayttajatiedotRepository = kayttajatiedotRepository;
+    }
+
+    @Override
+    public void execute(TaskInstance<Void> taskInstance, ExecutionContext executionContext) {
+        log.info("Purging mismatching identifications");
+        kayttajatiedotRepository.cleanObsoletedIdentifications();
+    }
+}

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/scheduling/SchedulingClusterConfiguration.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/scheduling/SchedulingClusterConfiguration.java
@@ -31,7 +31,8 @@ public class SchedulingClusterConfiguration {
                         CasClientSessionCleanerTask casClientSessionCleanerTask,
                         UpdateHenkiloNimiCacheTask updateHenkiloNimiCacheTask,
                         DiscardExpiredInvitationsTask discardExpiredInvitationsTask,
-                        DiscardExpiredApplicationsTask discardExpiredApplicationsTask) {
+                        DiscardExpiredApplicationsTask discardExpiredApplicationsTask,
+                        IdentificationCleanupTask identificationCleanupTask) { // NOSONAR
         Scheduler scheduler = Scheduler.create(dataSource)
                 .startTasks(lahetaUusienAnomuksienIlmoituksetTask,
                         poistaVanhentuneetKayttooikeudetTask,
@@ -40,7 +41,8 @@ public class SchedulingClusterConfiguration {
                         casClientSessionCleanerTask,
                         updateHenkiloNimiCacheTask,
                         discardExpiredInvitationsTask,
-                        discardExpiredApplicationsTask)
+                        discardExpiredApplicationsTask,
+                        identificationCleanupTask)
                 .threads(this.kayttooikeusProperties.getScheduling().getPool_size())
                 .build();
         scheduler.start();

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/KayttajatiedotRepository.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/KayttajatiedotRepository.java
@@ -2,7 +2,10 @@ package fi.vm.sade.kayttooikeus.repositories;
 
 import fi.vm.sade.kayttooikeus.model.Henkilo;
 import fi.vm.sade.kayttooikeus.model.Kayttajatiedot;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -12,4 +15,15 @@ public interface KayttajatiedotRepository extends CrudRepository<Kayttajatiedot,
 
     long deleteByHenkilo(Henkilo henkilo);
 
+    @Modifying
+    @Transactional
+    @Query(value= "DELETE FROM identification WHERE id IN (" +
+            "   SELECT i.id FROM " +
+            "       identification i, " +
+            "       kayttajatiedot k" +
+            "   WHERE " +
+            "       i.idpentityid != 'haka' " +
+            "       AND k.henkiloid = i.henkilo_id " +
+            "       AND k.username != i.identifier)", nativeQuery = true)
+    void cleanObsoletedIdentifications();
 }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/KayttajatiedotRepository.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/repositories/KayttajatiedotRepository.java
@@ -17,13 +17,10 @@ public interface KayttajatiedotRepository extends CrudRepository<Kayttajatiedot,
 
     @Modifying
     @Transactional
-    @Query(value= "DELETE FROM identification WHERE id IN (" +
-            "   SELECT i.id FROM " +
-            "       identification i, " +
-            "       kayttajatiedot k" +
-            "   WHERE " +
-            "       i.idpentityid != 'haka' " +
-            "       AND k.henkiloid = i.henkilo_id " +
-            "       AND k.username != i.identifier)", nativeQuery = true)
-    void cleanObsoletedIdentifications();
+    @Query(value = "DELETE FROM identification WHERE id IN (" +
+            "SELECT i.id FROM identification i " +
+            "LEFT JOIN kayttajatiedot k ON i.henkilo_id = k.henkiloid " +
+            "WHERE i.idpentityid IN ('cas', 'vetuma') " +
+            "AND i.identifier != COALESCE(k.username, ''))", nativeQuery = true)
+    int cleanObsoletedIdentifications();
 }

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/config/scheduling/IdentificationCleanupTaskTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/config/scheduling/IdentificationCleanupTaskTest.java
@@ -26,7 +26,6 @@ public class IdentificationCleanupTaskTest {
 
     @Test
     public void execute() {
-
         identificationCleanupTask.execute(null, null);
         verify(kayttajatiedotRepository, times(1)).cleanObsoletedIdentifications();
     }

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/config/scheduling/IdentificationCleanupTaskTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/config/scheduling/IdentificationCleanupTaskTest.java
@@ -1,0 +1,33 @@
+package fi.vm.sade.kayttooikeus.config.scheduling;
+
+import fi.vm.sade.kayttooikeus.config.properties.KayttooikeusProperties;
+import fi.vm.sade.kayttooikeus.repositories.KayttajatiedotRepository;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(SpringRunner.class)
+public class IdentificationCleanupTaskTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private KayttooikeusProperties kayttooikeusProperties;
+
+    @Mock
+    private KayttajatiedotRepository kayttajatiedotRepository;
+
+    @InjectMocks
+    private IdentificationCleanupTask identificationCleanupTask;
+
+    @Test
+    public void execute() {
+
+        identificationCleanupTask.execute(null, null);
+        verify(kayttajatiedotRepository, times(1)).cleanObsoletedIdentifications();
+    }
+}

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/repositories/impl/KayttajatiedotRepositoryImplTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/repositories/impl/KayttajatiedotRepositoryImplTest.java
@@ -1,22 +1,25 @@
 package fi.vm.sade.kayttooikeus.repositories.impl;
 
 import fi.vm.sade.kayttooikeus.dto.KayttajatiedotReadDto;
-import java.util.Optional;
-import static org.assertj.core.api.Assertions.assertThat;
-
+import fi.vm.sade.kayttooikeus.model.Identification;
 import fi.vm.sade.kayttooikeus.repositories.KayttajatiedotRepository;
 import fi.vm.sade.kayttooikeus.service.PermissionCheckerService;
 import fi.vm.sade.kayttooikeus.service.external.OrganisaatioClient;
+import fi.vm.sade.kayttooikeus.service.it.AbstractServiceIntegrationTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.util.Optional;
+
+import static fi.vm.sade.kayttooikeus.repositories.populate.HenkiloPopulator.henkilo;
+import static fi.vm.sade.kayttooikeus.repositories.populate.IdentificationPopulator.identification;
+import static org.assertj.core.api.Assertions.assertThat;
+
 @RunWith(SpringRunner.class)
-@DataJpaTest
-public class KayttajatiedotRepositoryImplTest {
+public class KayttajatiedotRepositoryImplTest extends AbstractServiceIntegrationTest {
 
     @Autowired
     private KayttajatiedotRepository repository;
@@ -37,7 +40,31 @@ public class KayttajatiedotRepositoryImplTest {
     }
 
     @Test
-    public void cleanObsoletedIdentification() { // NOSONAR
-        repository.cleanObsoletedIdentifications();
+    public void cleanObsoletedIdentifications() {
+        assertThat(repository.cleanObsoletedIdentifications()).isZero();
+    }
+
+    @Test
+    public void cleanObsoletedIdentificationsReportsCorrectly() {
+        populate(identification(Identification.CAS_AUTHENTICATION_IDP, "foo", henkilo("oid").withUsername("bar")));
+        assertThat(repository.cleanObsoletedIdentifications()).isEqualTo(1);
+    }
+
+    @Test
+    public void cleanObsoletedIdentificationsSkipsProtectedIDPs() {
+        populate(identification(Identification.HAKA_AUTHENTICATION_IDP, "foo", henkilo("oid").withUsername("bar")));
+        assertThat(repository.cleanObsoletedIdentifications()).isZero();
+    }
+
+    @Test
+    public void cleanObsoletedIdentificationsSkipCorrectlyMatching() {
+        populate(identification(Identification.CAS_AUTHENTICATION_IDP, "foo", henkilo("oid").withUsername("foo")));
+        assertThat(repository.cleanObsoletedIdentifications()).isZero();
+    }
+
+    @Test
+    public void cleanObsoletedIdentificationsHandlesNullUsernames() {
+        populate(identification(Identification.CAS_AUTHENTICATION_IDP, "foo", henkilo("oid")));
+        assertThat(repository.cleanObsoletedIdentifications()).isEqualTo(1);
     }
 }

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/repositories/impl/KayttajatiedotRepositoryImplTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/repositories/impl/KayttajatiedotRepositoryImplTest.java
@@ -4,6 +4,7 @@ import fi.vm.sade.kayttooikeus.dto.KayttajatiedotReadDto;
 import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import fi.vm.sade.kayttooikeus.repositories.KayttajatiedotRepository;
 import fi.vm.sade.kayttooikeus.service.PermissionCheckerService;
 import fi.vm.sade.kayttooikeus.service.external.OrganisaatioClient;
 import org.junit.Test;
@@ -18,7 +19,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class KayttajatiedotRepositoryImplTest {
 
     @Autowired
-    private KayttajatiedotRepositoryImpl repository;
+    private KayttajatiedotRepository repository;
 
     @MockBean
     PermissionCheckerService permissionCheckerService;
@@ -35,4 +36,8 @@ public class KayttajatiedotRepositoryImplTest {
         assertThat(kayttajatiedot).isEmpty();
     }
 
+    @Test
+    public void cleanObsoletedIdentification() { // NOSONAR
+        repository.cleanObsoletedIdentifications();
+    }
 }


### PR DESCRIPTION
* Identification is tied to user details but stored separately. this
  may lead to situation where login is prevented when username is
  being reused.
* This is simplified approach for solving given problem e.g. does not solve the actual problem but mitigates consequences
* PR created prior taking to actual testing