### PR TITLE
Shrink payload size by omitting leafs from organisation names response

### DIFF
--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/OrganisaatioServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/OrganisaatioServiceImpl.java
@@ -57,6 +57,10 @@ public class OrganisaatioServiceImpl implements OrganisaatioService {
         };
     }
 
+    private static Predicate<OrganisaatioPerustieto> hasChildren() {
+        return (OrganisaatioPerustieto organisaatio) -> organisaatio.getChildren() != null && !organisaatio.getChildren().isEmpty();
+    }
+
     private static Predicate<OrganisaatioPerustieto> tilaPredicate(Set<OrganisaatioStatus> tila) {
         return (OrganisaatioPerustieto organisaatio) -> tila.contains(organisaatio.getStatus());
     }
@@ -129,6 +133,7 @@ public class OrganisaatioServiceImpl implements OrganisaatioService {
         return organisaatioClient
                 .stream()
                 .filter(tyyppiPredicate(OrganisaatioTyyppi.ORGANISAATIO))
+                .filter(hasChildren())
                 .collect(Collectors.toMap(OrganisaatioPerustieto::getOid, OrganisaatioPerustieto::getNimi));
     }
 

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/impl/OrganisaatioServiceImplTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/impl/OrganisaatioServiceImplTest.java
@@ -59,10 +59,22 @@ public class OrganisaatioServiceImplTest {
 
     @Test
     public void getOrganisaatioNames() {
+        OrganisaatioPerustieto vaka1 = OrganisaatioPerustieto.builder()
+                .oid("org.vaka1.oid")
+                .organisaatiotyypit(List.of("organisaatiotyyppi_08"))
+                .nimi(Collections.singletonMap("lang", "vaka1"))
+                .build();
+        OrganisaatioPerustieto vaka2 = OrganisaatioPerustieto.builder()
+                .oid("org.vaka2.oid")
+                .organisaatiotyypit(List.of("organisaatiotyyppi_08"))
+                .nimi(Collections.singletonMap("lang", "vaka2"))
+                .children(List.of())
+                .build();
         OrganisaatioPerustieto org = OrganisaatioPerustieto.builder()
                 .oid("org.10.oid")
                 .organisaatiotyypit(List.of("organisaatiotyyppi_03"))
                 .nimi(Collections.singletonMap("lang", "name"))
+                .children(List.of(vaka1, vaka2))
                 .build();
         OrganisaatioPerustieto group = OrganisaatioPerustieto.builder()
                 .oid("group.28.oid")
@@ -70,7 +82,7 @@ public class OrganisaatioServiceImplTest {
                 .nimi(Collections.singletonMap("groups", "are filtered from output"))
                 .build();
 
-        when(organisaatioClientMock.stream()).thenReturn(Stream.of(org, group));
+        when(organisaatioClientMock.stream()).thenReturn(Stream.of(org, vaka1, vaka2, group));
 
         Map<String, Map<String, String>> result = organisaatioServiceImpl.getOrganisationNames();
 


### PR DESCRIPTION
Data is used by henkilö UI to resolve organisation parent names, actual organisation name is obtained by other means -> leaves are not needed. Seems that this has has considerable effect on payload size (811kB -> 147kB) 