### PR TITLE
Uusi tekstikenttä "kutsuja" kutsurajapintaan.

### DIFF
--- a/kayttooikeus-api/src/main/java/fi/vm/sade/kayttooikeus/dto/KutsuCreateDto.java
+++ b/kayttooikeus-api/src/main/java/fi/vm/sade/kayttooikeus/dto/KutsuCreateDto.java
@@ -19,6 +19,8 @@ public class KutsuCreateDto {
 
     private String kutsujaOid;
 
+    private String kutsujaForEmail;
+
     @NotEmpty
     private String etunimi;
     @NotEmpty

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/HttpClientConfiguration.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/config/HttpClientConfiguration.java
@@ -1,7 +1,8 @@
 package fi.vm.sade.kayttooikeus.config;
 
-import fi.vm.sade.javautils.http.OphHttpClient;
+import fi.vm.sade.javautils.httpclient.apache.ApacheOphHttpClient;
 import fi.vm.sade.javautils.http.auth.CasAuthenticator;
+import fi.vm.sade.javautils.httpclient.OphHttpClient;
 import fi.vm.sade.kayttooikeus.config.properties.ServiceUsersProperties;
 import fi.vm.sade.kayttooikeus.config.properties.UrlConfiguration;
 import org.slf4j.Logger;
@@ -24,22 +25,23 @@ public class HttpClientConfiguration {
     @Bean
     @Primary
     public OphHttpClient httpClient() {
-        return new OphHttpClient.Builder(CALLER_ID).build();
+        return ApacheOphHttpClient.createDefaultOphClient(CALLER_ID, null);
     }
 
+
     @Bean(HTTP_CLIENT_OPPIJANUMEROREKISTERI)
-    public OphHttpClient httpClientOppijanumerorekisteri(UrlConfiguration properties, ServiceUsersProperties serviceUsersProperties) {
+    public fi.vm.sade.javautils.http.OphHttpClient httpClientOppijanumerorekisteri(UrlConfiguration properties, ServiceUsersProperties serviceUsersProperties) {
         CasAuthenticator authenticator = new CasAuthenticator.Builder()
                 .username(serviceUsersProperties.getOppijanumerorekisteri().getUsername())
                 .password(serviceUsersProperties.getOppijanumerorekisteri().getPassword())
                 .webCasUrl(properties.url("cas.url"))
                 .casServiceUrl(properties.url("oppijanumerorekisteri-service.security-check"))
                 .build();
-        return new OphHttpClient.Builder(CALLER_ID).authenticator(authenticator).build();
+        return new fi.vm.sade.javautils.http.OphHttpClient.Builder(CALLER_ID).authenticator(authenticator).build();
     }
 
     @Bean(HTTP_CLIENT_ORGANISAATIO)
-    public OphHttpClient httpClientOrganisaatio(UrlConfiguration properties, ServiceUsersProperties serviceUsersProperties) {
+    public fi.vm.sade.javautils.http.OphHttpClient httpClientOrganisaatio(UrlConfiguration properties, ServiceUsersProperties serviceUsersProperties) {
         int timeout = Integer.parseInt(properties.getOrElse("organisaatio-service.timeout", DEFAULT_TIMEOUT));
         LOGGER.info("Organisaatio HTTP client timeout: {} ms", timeout);
         CasAuthenticator authenticator = new CasAuthenticator.Builder()
@@ -48,7 +50,7 @@ public class HttpClientConfiguration {
                 .webCasUrl(properties.url("cas.url"))
                 .casServiceUrl(properties.url("organisaatio-service.security-check"))
                 .build();
-        return new OphHttpClient.Builder(CALLER_ID)
+        return new fi.vm.sade.javautils.http.OphHttpClient.Builder(CALLER_ID)
                 .timeoutMs(timeout)
                 .setSocketTimeoutMs(timeout)
                 .authenticator(authenticator)
@@ -56,14 +58,14 @@ public class HttpClientConfiguration {
     }
 
     @Bean(HTTP_CLIENT_VIESTINTA)
-    public OphHttpClient httpClientViestinta(UrlConfiguration properties, ServiceUsersProperties serviceUsersProperties) {
+    public fi.vm.sade.javautils.http.OphHttpClient httpClientViestinta(UrlConfiguration properties, ServiceUsersProperties serviceUsersProperties) {
         CasAuthenticator authenticator = new CasAuthenticator.Builder()
                 .username(serviceUsersProperties.getViestinta().getUsername())
                 .password(serviceUsersProperties.getViestinta().getPassword())
                 .webCasUrl(properties.url("cas.url"))
                 .casServiceUrl(properties.url("ryhmasahkoposti-service.security-check"))
                 .build();
-        return new OphHttpClient.Builder(CALLER_ID).authenticator(authenticator).build();
+        return new fi.vm.sade.javautils.http.OphHttpClient.Builder(CALLER_ID).authenticator(authenticator).build();
     }
 
 }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/EmailService.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/EmailService.java
@@ -1,6 +1,5 @@
 package fi.vm.sade.kayttooikeus.service;
 
-import fi.vm.sade.kayttooikeus.dto.KutsuCreateDto;
 import fi.vm.sade.kayttooikeus.dto.UpdateHaettuKayttooikeusryhmaDto;
 import fi.vm.sade.kayttooikeus.model.Anomus;
 import fi.vm.sade.kayttooikeus.model.Kutsu;

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/EmailService.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/EmailService.java
@@ -1,5 +1,6 @@
 package fi.vm.sade.kayttooikeus.service;
 
+import fi.vm.sade.kayttooikeus.dto.KutsuCreateDto;
 import fi.vm.sade.kayttooikeus.dto.UpdateHaettuKayttooikeusryhmaDto;
 import fi.vm.sade.kayttooikeus.model.Anomus;
 import fi.vm.sade.kayttooikeus.model.Kutsu;
@@ -16,7 +17,7 @@ public interface EmailService {
 
     void sendNewRequisitionNotificationEmails(Set<String> henkiloOids);
 
-    void sendInvitationEmail(Kutsu kutsu);
+    void sendInvitationEmail(Kutsu kutsu, String kutsujaForEmail);
 
     void sendDiscardNotification(Kutsu invitation);
 

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/EmailService.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/EmailService.java
@@ -19,6 +19,8 @@ public interface EmailService {
 
     void sendInvitationEmail(Kutsu kutsu, String kutsujaForEmail);
 
+    void sendInvitationEmail(Kutsu kutsu);
+
     void sendDiscardNotification(Kutsu invitation);
 
     void sendDiscardNotification(Anomus application);

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/external/impl/ExternalPermissionClientImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/external/impl/ExternalPermissionClientImpl.java
@@ -1,22 +1,19 @@
 package fi.vm.sade.kayttooikeus.service.external.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import fi.vm.sade.javautils.http.OphHttpClient;
-import fi.vm.sade.javautils.http.OphHttpEntity;
-import fi.vm.sade.javautils.http.OphHttpRequest;
+import fi.vm.sade.javautils.httpclient.OphHttpClient;
 import fi.vm.sade.kayttooikeus.dto.permissioncheck.ExternalPermissionService;
 import fi.vm.sade.kayttooikeus.dto.permissioncheck.PermissionCheckRequestDto;
 import fi.vm.sade.kayttooikeus.dto.permissioncheck.PermissionCheckResponseDto;
 import fi.vm.sade.kayttooikeus.service.external.ExternalPermissionClient;
 import fi.vm.sade.properties.OphProperties;
-import org.apache.http.entity.ContentType;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static fi.vm.sade.kayttooikeus.service.external.impl.HttpClientUtil.noContentOrNotFoundException;
-import static fi.vm.sade.kayttooikeus.util.FunctionalUtils.io;
+import static fi.vm.sade.javautils.httpclient.OphHttpClient.JSON;
+import static fi.vm.sade.javautils.httpclient.OphHttpClient.UTF8;
 import static java.util.Objects.requireNonNull;
 
 @Component
@@ -41,17 +38,9 @@ public class ExternalPermissionClientImpl implements ExternalPermissionClient {
     @Override
     public PermissionCheckResponseDto getPermission(ExternalPermissionService service, PermissionCheckRequestDto requestDto) {
         String url = requireNonNull(SERVICE_URIS.get(service), "service uri puuttuu: " + service);
-        OphHttpRequest request = OphHttpRequest.Builder
-                .post(url)
-                .setEntity(new OphHttpEntity.Builder()
-                        .content(io(() -> objectMapper.writeValueAsString(requestDto)).get())
-                        .contentType(ContentType.APPLICATION_JSON)
-                        .build())
-                .build();
-        return httpClient.<PermissionCheckResponseDto>execute(request)
-                .expectedStatus(200)
-                .mapWith(json -> io(() -> objectMapper.readValue(json, PermissionCheckResponseDto.class)).get())
-                .orElseThrow(() -> noContentOrNotFoundException(url));
+        return httpClient.post(url)
+                .dataWriter(JSON, UTF8, out -> out.write(objectMapper.writeValueAsString(requestDto)))
+                .execute(response -> objectMapper.readValue(response.asInputStream(), PermissionCheckResponseDto.class));
     }
 
 }

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/EmailServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/EmailServiceImpl.java
@@ -2,10 +2,7 @@ package fi.vm.sade.kayttooikeus.service.impl;
 
 import com.google.common.collect.Lists;
 import fi.vm.sade.kayttooikeus.config.OrikaBeanMapper;
-import fi.vm.sade.kayttooikeus.dto.AnomusKasiteltyRecipientDto;
-import fi.vm.sade.kayttooikeus.dto.KayttoOikeudenTila;
-import fi.vm.sade.kayttooikeus.dto.TextGroupMapDto;
-import fi.vm.sade.kayttooikeus.dto.UpdateHaettuKayttooikeusryhmaDto;
+import fi.vm.sade.kayttooikeus.dto.*;
 import fi.vm.sade.kayttooikeus.model.Anomus;
 import fi.vm.sade.kayttooikeus.model.Henkilo;
 import fi.vm.sade.kayttooikeus.model.KayttoOikeusRyhma;
@@ -229,8 +226,11 @@ public class EmailServiceImpl implements EmailService {
         ryhmasahkopostiClient.sendRyhmasahkoposti(data);
     }
 
-    public void sendInvitationEmail(Kutsu kutsu) {
-        HenkiloDto kutsuja = this.oppijanumerorekisteriClient.getHenkiloByOid(kutsu.getKutsuja());
+    public void sendInvitationEmail(Kutsu kutsu, String kutsujaForEmail) {
+        if (kutsujaForEmail == null) {
+            HenkiloDto kutsuja = this.oppijanumerorekisteriClient.getHenkiloByOid(kutsu.getKutsuja());
+            kutsujaForEmail = String.format("%s %s", kutsuja.getKutsumanimi(), kutsuja.getSukunimi());
+        }
 
         EmailData emailData = new EmailData();
 
@@ -272,7 +272,7 @@ public class EmailServiceImpl implements EmailService {
                                 )
                         ).sorted(comparing(OranizationReplacement::getName)).collect(toList())),
                 replacement("saate", kutsu.getSaate()),
-                replacement("kutsuja", mapper.map(kutsuja, SahkopostiHenkiloDto.class)),
+                replacement("kutsuja", kutsujaForEmail),
                 replacement("voimassa", kutsu.getAikaleima().plusMonths(1).format(DateTimeFormatter.ofPattern("dd.MM.yyyy")))
         ));
         emailData.setRecipient(singletonList(recipient));

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/EmailServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/EmailServiceImpl.java
@@ -226,14 +226,14 @@ public class EmailServiceImpl implements EmailService {
         ryhmasahkopostiClient.sendRyhmasahkoposti(data);
     }
 
+    public void sendInvitationEmail(Kutsu kutsu) {
+        HenkiloDto kutsuja = this.oppijanumerorekisteriClient.getHenkiloByOid(kutsu.getKutsuja());
+        String kutsujaForEmail = String.format("%s %s", kutsuja.getKutsumanimi(), kutsuja.getSukunimi());
+        sendInvitationEmail(kutsu, kutsujaForEmail);
+    }
+
     public void sendInvitationEmail(Kutsu kutsu, String kutsujaForEmail) {
-        if (kutsujaForEmail == null) {
-            HenkiloDto kutsuja = this.oppijanumerorekisteriClient.getHenkiloByOid(kutsu.getKutsuja());
-            kutsujaForEmail = String.format("%s %s", kutsuja.getKutsumanimi(), kutsuja.getSukunimi());
-        }
-
         EmailData emailData = new EmailData();
-
         EmailMessage email = new EmailMessage();
         email.setTemplateName(KUTSUTTU_EMAIL_TEMPLATE_NAME);
         email.setLanguageCode(kutsu.getKieliKoodi());

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KutsuServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KutsuServiceImpl.java
@@ -226,7 +226,7 @@ public class KutsuServiceImpl implements KutsuService {
         }
         kutsuToRenew.setAikaleima(LocalDateTime.now());
         kutsuToRenew = kutsuRepository.save(kutsuToRenew);
-        emailService.sendInvitationEmail(kutsuToRenew, null);
+        emailService.sendInvitationEmail(kutsuToRenew);
     }
 
     @Override

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KutsuServiceImpl.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/KutsuServiceImpl.java
@@ -121,7 +121,7 @@ public class KutsuServiceImpl implements KutsuService {
 
         Kutsu persistedNewKutsu = this.kutsuRepository.save(newKutsu);
 
-        this.emailService.sendInvitationEmail(persistedNewKutsu);
+        this.emailService.sendInvitationEmail(persistedNewKutsu, kutsuCreateDto.getKutsujaForEmail());
 
         return persistedNewKutsu.getId();
     }
@@ -226,7 +226,7 @@ public class KutsuServiceImpl implements KutsuService {
         }
         kutsuToRenew.setAikaleima(LocalDateTime.now());
         kutsuToRenew = kutsuRepository.save(kutsuToRenew);
-        emailService.sendInvitationEmail(kutsuToRenew);
+        emailService.sendInvitationEmail(kutsuToRenew, null);
     }
 
     @Override

--- a/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/email/SahkopostiHenkiloDto.java
+++ b/kayttooikeus-service/src/main/java/fi/vm/sade/kayttooikeus/service/impl/email/SahkopostiHenkiloDto.java
@@ -11,4 +11,8 @@ public class SahkopostiHenkiloDto {
     private String kutsumanimi;
     private String sukunimi;
 
+    @Override
+    public String toString() {
+        return kutsumanimi + " " + sukunimi;
+    }
 }

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/EmailServiceTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/EmailServiceTest.java
@@ -268,8 +268,8 @@ public class EmailServiceTest extends AbstractServiceTest {
                 .extracting("name")
                 .containsExactlyInAnyOrder("vastaanottaja", "organisaatiot", "linkki", "kutsuja", "voimassa", "saate");
         assertTrue(emailData.getRecipient().get(0).getRecipientReplacements().stream().anyMatch(r -> Objects.equals(r.getName(), "kutsuja") && Objects.equals(r.getValue(), kutsuja.toString()) ));
-        assertThat(emailData.getRecipient().get(0).getOid()).isEqualTo("");
-        assertThat(emailData.getRecipient().get(0).getOidType()).isEqualTo("");
+        assertThat(emailData.getRecipient().get(0).getOid()).isEmpty();
+        assertThat(emailData.getRecipient().get(0).getOidType()).isEmpty();
         assertThat(emailData.getRecipient().get(0).getEmail()).isEqualTo("arpa@kuutio.fi");
         assertThat(emailData.getRecipient().get(0).getName()).isEqualTo("arpa kuutio");
         assertThat(emailData.getRecipient().get(0).getLanguageCode()).isEqualTo("fi");
@@ -317,8 +317,8 @@ public class EmailServiceTest extends AbstractServiceTest {
                 .containsExactlyInAnyOrder("vastaanottaja", "organisaatiot", "linkki", "kutsuja", "voimassa", "saate");
 
         assertTrue(emailData.getRecipient().get(0).getRecipientReplacements().stream().anyMatch(r -> Objects.equals(r.getName(), "kutsuja") && Objects.equals(r.getValue(), expectedKutsuja) ));
-        assertThat(emailData.getRecipient().get(0).getOid()).isEqualTo("");
-        assertThat(emailData.getRecipient().get(0).getOidType()).isEqualTo("");
+        assertThat(emailData.getRecipient().get(0).getOid()).isEmpty();
+        assertThat(emailData.getRecipient().get(0).getOidType()).isEmpty();
         assertThat(emailData.getRecipient().get(0).getEmail()).isEqualTo("arpa@kuutio.fi");
         assertThat(emailData.getRecipient().get(0).getName()).isEqualTo("arpa kuutio");
         assertThat(emailData.getRecipient().get(0).getLanguageCode()).isEqualTo("fi");

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/EmailServiceTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/EmailServiceTest.java
@@ -1,16 +1,15 @@
 package fi.vm.sade.kayttooikeus.service;
 
 import com.google.common.collect.Sets;
+import fi.vm.sade.kayttooikeus.dto.KutsuCreateDto;
 import fi.vm.sade.kayttooikeus.dto.TextGroupDto;
 import fi.vm.sade.kayttooikeus.dto.UpdateHaettuKayttooikeusryhmaDto;
 import fi.vm.sade.kayttooikeus.model.*;
 import fi.vm.sade.kayttooikeus.repositories.KayttoOikeusRyhmaRepository;
 import fi.vm.sade.kayttooikeus.repositories.dto.ExpiringKayttoOikeusDto;
-import fi.vm.sade.kayttooikeus.service.external.OppijanumerorekisteriClient;
-import fi.vm.sade.kayttooikeus.service.external.OrganisaatioClient;
-import fi.vm.sade.kayttooikeus.service.external.OrganisaatioPerustieto;
-import fi.vm.sade.kayttooikeus.service.external.RyhmasahkopostiClient;
+import fi.vm.sade.kayttooikeus.service.external.*;
 import fi.vm.sade.kayttooikeus.service.impl.EmailServiceImpl;
+import fi.vm.sade.kayttooikeus.service.impl.email.SahkopostiHenkiloDto;
 import fi.vm.sade.kayttooikeus.util.CreateUtil;
 import fi.vm.sade.kayttooikeus.util.YhteystietoUtil;
 import fi.vm.sade.oppijanumerorekisteri.dto.*;
@@ -31,11 +30,13 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.Optional;
 
 import static java.util.Collections.singleton;
 import static java.util.Optional.of;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -237,6 +238,9 @@ public class EmailServiceTest extends AbstractServiceTest {
         organisaatioPerustieto.setNimi(new HashMap<String, String>() {{
             put("fi", "suomenkielinennimi");
         }});
+        SahkopostiHenkiloDto kutsuja = new SahkopostiHenkiloDto();
+        kutsuja.setKutsumanimi("kutsun");
+        kutsuja.setSukunimi("kutsuja");
         given(this.organisaatioClient.getOrganisaatioPerustiedotCached(any()))
                 .willReturn(Optional.of(organisaatioPerustieto));
         given(this.oppijanumerorekisteriClient.getHenkiloByOid(any()))
@@ -255,7 +259,7 @@ public class EmailServiceTest extends AbstractServiceTest {
                 .aikaleima(LocalDateTime.now())
                 .build();
 
-        this.emailService.sendInvitationEmail(kutsu);
+        this.emailService.sendInvitationEmail(kutsu, null);
         ArgumentCaptor<EmailData> emailDataArgumentCaptor = ArgumentCaptor.forClass(EmailData.class);
         verify(this.ryhmasahkopostiClient).sendRyhmasahkoposti(emailDataArgumentCaptor.capture());
         EmailData emailData = emailDataArgumentCaptor.getValue();
@@ -263,6 +267,56 @@ public class EmailServiceTest extends AbstractServiceTest {
         assertThat(emailData.getRecipient().get(0).getRecipientReplacements())
                 .extracting("name")
                 .containsExactlyInAnyOrder("vastaanottaja", "organisaatiot", "linkki", "kutsuja", "voimassa", "saate");
+        assertTrue(emailData.getRecipient().get(0).getRecipientReplacements().stream().anyMatch(r -> Objects.equals(r.getName(), "kutsuja") && Objects.equals(r.getValue(), kutsuja.toString()) ));
+        assertThat(emailData.getRecipient().get(0).getOid()).isEqualTo("");
+        assertThat(emailData.getRecipient().get(0).getOidType()).isEqualTo("");
+        assertThat(emailData.getRecipient().get(0).getEmail()).isEqualTo("arpa@kuutio.fi");
+        assertThat(emailData.getRecipient().get(0).getName()).isEqualTo("arpa kuutio");
+        assertThat(emailData.getRecipient().get(0).getLanguageCode()).isEqualTo("fi");
+
+        assertThat(emailData.getEmail().getCallingProcess()).isEqualTo("kayttooikeus");
+        assertThat(emailData.getEmail().getLanguageCode()).isEqualTo("fi");
+        assertThat(emailData.getEmail().getFrom()).isNull();
+        assertThat(emailData.getEmail().getTemplateName()).isEqualTo("kayttooikeus_kutsu_v2");
+    }
+
+    @Test
+    public void sendInvitationEmailAsServiceKutsuja() {
+        OrganisaatioPerustieto organisaatioPerustieto = new OrganisaatioPerustieto();
+        organisaatioPerustieto.setNimi(new HashMap<String, String>() {{
+            put("fi", "suomenkielinennimi");
+        }});
+
+        String expectedKutsuja =  "Varda Info";
+
+        given(this.organisaatioClient.getOrganisaatioPerustiedotCached(any()))
+                .willReturn(Optional.of(organisaatioPerustieto));
+        given(this.oppijanumerorekisteriClient.getHenkiloByOid(any()))
+                .willReturn(HenkiloDto.builder().kutsumanimi("kutsun").sukunimi("kutsuja").build());
+        Kutsu kutsu = Kutsu.builder()
+                .kieliKoodi("fi")
+                .sahkoposti("arpa@kuutio.fi")
+                .salaisuus("salaisuushash")
+                .etunimi("arpa")
+                .sukunimi("kuutio")
+                .saate(null)
+                .organisaatiot(Sets.newHashSet(KutsuOrganisaatio.builder()
+                        .organisaatioOid("1.2.3.4.1")
+                        .ryhmat(Sets.newHashSet(KayttoOikeusRyhma.builder().nimi(new TextGroup()).build()))
+                        .build()))
+                .aikaleima(LocalDateTime.now())
+                .build();
+
+        this.emailService.sendInvitationEmail(kutsu, expectedKutsuja);
+        ArgumentCaptor<EmailData> emailDataArgumentCaptor = ArgumentCaptor.forClass(EmailData.class);
+        verify(this.ryhmasahkopostiClient).sendRyhmasahkoposti(emailDataArgumentCaptor.capture());
+        EmailData emailData = emailDataArgumentCaptor.getValue();
+        assertThat(emailData.getRecipient()).hasSize(1);
+        assertThat(emailData.getRecipient().get(0).getRecipientReplacements())
+                .extracting("name")
+                .containsExactlyInAnyOrder("vastaanottaja", "organisaatiot", "linkki", "kutsuja", "voimassa", "saate");
+
+        assertTrue(emailData.getRecipient().get(0).getRecipientReplacements().stream().anyMatch(r -> Objects.equals(r.getName(), "kutsuja") && Objects.equals(r.getValue(), expectedKutsuja) ));
         assertThat(emailData.getRecipient().get(0).getOid()).isEqualTo("");
         assertThat(emailData.getRecipient().get(0).getOidType()).isEqualTo("");
         assertThat(emailData.getRecipient().get(0).getEmail()).isEqualTo("arpa@kuutio.fi");

--- a/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/EmailServiceTest.java
+++ b/kayttooikeus-service/src/test/java/fi/vm/sade/kayttooikeus/service/EmailServiceTest.java
@@ -259,7 +259,7 @@ public class EmailServiceTest extends AbstractServiceTest {
                 .aikaleima(LocalDateTime.now())
                 .build();
 
-        this.emailService.sendInvitationEmail(kutsu, null);
+        this.emailService.sendInvitationEmail(kutsu);
         ArgumentCaptor<EmailData> emailDataArgumentCaptor = ArgumentCaptor.forClass(EmailData.class);
         verify(this.ryhmasahkopostiClient).sendRyhmasahkoposti(emailDataArgumentCaptor.capture());
         EmailData emailData = emailDataArgumentCaptor.getValue();


### PR DESCRIPTION
Lisätty kutsuja kenttä kutsurajapintaan jolla voidaan välittää valinnaiset kutsujan tiedot suoraan sähköposti tempateen sen sijaan että sen pitäisi aina olla henkilö. Samallla tässä tuli puoli vahingossa korjaus tikettiin https://jira.eduuni.fi/browse/KJHH-2206 kun päivitin ophttpclientin yksinkertaisempaan toteutukseen.